### PR TITLE
fix(labels): rimuovi label di stato, usa solo agente + progetto

### DIFF
--- a/skills/8020-workflow/SKILL.md
+++ b/skills/8020-workflow/SKILL.md
@@ -38,10 +38,9 @@ Davide testa:
 
 ## Quando Ciccio riceve /reject
 1. Aggiungi commento GitHub con feedback completo
-2. Rimuovi `deployed-test`, aggiungi `needs-fix`
-3. Sposta card: `Test` → `Review`
-4. Lavora il fix → quando pronto → sposta card: `Review` → `Test`
-5. Notifica Davide con nuovo APK/link
+2. Sposta card: `Test` → `Review` (non toccare le label)
+3. Lavora il fix → quando pronto → sposta card: `Review` → `Test`
+4. Notifica Davide con nuovo APK/link
 
 ## Quando Ciccio riceve /approve
 1. Mergia PR su master
@@ -63,20 +62,20 @@ Davide testa:
 - **Deploy key**: `/root/.ssh/github-actions-deploy`
 
 ## Labels sistema
+Le issue usano **sole due label**:
+1. **Label progetto** — nome del progetto (es. `beachref`, `finn`)
+2. **Label agente** — chi lavora l'issue (`ciccio`, `claude-code`, `codex`)
+
 | Label | Significato |
 |-------|-------------|
 | `ciccio` | Ciccio (VPS) — routing obbligatorio |
 | `claude-code` | Claude Code (PC) — routing obbligatorio |
 | `codex` | Codex (PC) — routing obbligatorio |
-| `in-progress` | In lavorazione (agente attivo) |
-| `review-ready` | Pronto per deploy/test |
-| `deployed-test` | Live su ambiente test |
-| `needs-fix` | Rework richiesto — NON cambia routing, si abbina a ciccio/claude-code/codex |
 
-## Regola routing
-- Label agente (`ciccio`/`claude-code`/`codex`) NON viene mai rimossa durante la lavorazione
-- `needs-fix` è un segnale di rework: il monitor che gestisce la label agente la prende
-- VPS skippa sempre issue con `claude-code` o `codex` (anche se hanno `needs-fix`)
+**Regole:**
+- Le label di stato (`in-progress`, `review-ready`, `deployed-test`, `needs-fix`) NON si usano — lo stato è indicato dalla colonna Kanban
+- Label agente NON viene mai rimossa durante la lavorazione
+- VPS skippa sempre issue con `claude-code` o `codex`
 
 ## Riferimenti completi
 - `references/WORKFLOW_CICCIO.md` — procedure complete Ciccio

--- a/skills/issue-done/SKILL.md
+++ b/skills/issue-done/SKILL.md
@@ -200,14 +200,11 @@ In attesa di build CI e deploy su test da parte di Claudio/Ciccio."
 
 ---
 
-## STEP 7 — Aggiorna label
+## STEP 7 — Label: non toccare
 
-```bash
-# Rimuovi in-progress, aggiungi review-ready
-gh issue edit <N> --repo <owner/repo> \
-  --remove-label "in-progress" \
-  --add-label "review-ready"
-```
+Le label NON vanno modificate al completamento.
+Mantieni solo label agente (`codex`, `claude-code`, `ciccio`) + label progetto.
+Lo stato è indicato dalla colonna Kanban.
 
 ---
 
@@ -230,7 +227,7 @@ gh issue edit <N> --repo <owner/repo> \
 - [ ] Branch pushato
 - [ ] PR aperta con body descrittivo (AC soddisfatti esplicitati)
 - [ ] Commento sull'issue
-- [ ] Label aggiornata → `review-ready`
+- [ ] Label NON toccate (solo agente + progetto rimangono)
 
 ---
 

--- a/skills/issue-reject/SKILL.md
+++ b/skills/issue-reject/SKILL.md
@@ -49,13 +49,11 @@ L'agente riprendera' la lavorazione sul branch feature/issue-<N>-<slug>."
 
 ---
 
-## STEP 3 — Aggiorna label
+## STEP 3 — Label: non toccare
 
-```bash
-gh issue edit <N> --repo <owner/repo> \
-  --remove-label "review-ready" \
-  --add-label "needs-fix"
-```
+Le label NON vanno modificate durante il reject.
+L'unica label da mantenere è quella dell'agente (`codex`, `claude-code`, `ciccio`) + quella del progetto.
+Lo stato è indicato dalla colonna Kanban, non dalle label.
 
 ---
 
@@ -122,7 +120,7 @@ Ciccio spawna subagente autonomamente con:
 
 - [ ] Feedback chiaro (se ambiguo -> chiesto chiarimento a Davide)
 - [ ] Commento registrato sull'issue con feedback dettagliato e AC fallito
-- [ ] Label aggiornata -> `needs-fix`
+- [ ] Label NON toccate (solo agente + progetto rimangono)
 - [ ] Card Kanban -> Review (`03f548ab`)
 - [ ] Agente notificato / rilanciato con feedback
 - [ ] Davide informato che il rework e' in corso


### PR DESCRIPTION
## Fix

Allineamento workflow alla regola: **le issue usano solo 2 label** — progetto + agente dev.

### Cosa è cambiato
- Rimossi tutti i riferimenti a \in-progress\, \eview-ready\, \deployed-test\, \
eeds-fix\
- Lo stato è indicato dalla colonna Kanban, non dalle label
- \issue-reject\: step label sostituito con nota 'non toccare'
- \issue-done\: step label sostituito con nota 'non toccare'
- \8020-workflow\: sezione Labels aggiornata con regola esplicita

Feedback diretto da Davide dopo reject issue #11 BeachRef-app.