### PR TITLE
docs: flag obbligatori lancio Claude Code e Codex

### DIFF
--- a/CLAUDE_CODE_PC_SETUP.md
+++ b/CLAUDE_CODE_PC_SETUP.md
@@ -148,6 +148,15 @@ claude --version
 claude "Hello, testing Claude CLI integration"
 ```
 
+### **⚠️ Flag obbligatori per lavoro autonomo:**
+```bash
+# Claude Code — bypassa prompt permessi (necessario per issue autonome)
+claude --dangerously-skip-permissions
+
+# Codex — modalità fully autonomous (nessuna conferma richiesta)
+codex --yolo
+```
+
 ### **Task Scheduler Manual Setup:**
 ```powershell
 # Import task manually if needed

--- a/WORKFLOW_CLAUDIO.md
+++ b/WORKFLOW_CLAUDIO.md
@@ -132,6 +132,22 @@ CI fallita? Agente bloccato? Card in stato sbagliato?
 
 ---
 
+## 🚀 Lancio Agenti PC
+
+### **Claude Code**
+```bash
+claude --dangerously-skip-permissions
+```
+Il flag bypassa i prompt di conferma permessi — necessario per lavoro autonomo su issue.
+
+### **Codex**
+```bash
+codex --yolo
+```
+Il flag abilita modalità fully autonomous (nessuna conferma richiesta) — necessario per lavoro autonomo su issue.
+
+---
+
 ## 🧠 Memoria e Continuità
 
 - **Ogni sessione**: leggo `SOUL.md`, `USER.md`, `memory/` recente, `MEMORY.md`


### PR DESCRIPTION
Aggiunge i flag di lancio nei docs del workflow:

- \claude --dangerously-skip-permissions\ per Claude Code
- \codex --yolo\ per Codex

Documentati in:
- \WORKFLOW_CLAUDIO.md\ — nuova sezione **Lancio Agenti PC**
- \CLAUDE_CODE_PC_SETUP.md\ — sezione Manual Configuration