### PR TITLE
fix(skills): issue-start aggiorna submodule + issue-done push/PR obbligatori

### DIFF
--- a/skills/issue-done/SKILL.md
+++ b/skills/issue-done/SKILL.md
@@ -155,15 +155,22 @@ Closes #22
 
 ---
 
-## STEP 4 — Push branch
+## ⚠️ STEP 4 — Push branch (OBBLIGATORIO)
+
+**Non saltare questo step.** Il push è obbligatorio — senza non puoi aprire la PR.
 
 ```bash
 git push -u origin feature/issue-<N>-<slug>
 ```
 
+Verifica che il push sia andato a buon fine prima di procedere.
+
 ---
 
-## STEP 5 — Apri PR
+## ⚠️ STEP 5 — Apri PR (OBBLIGATORIO)
+
+**Non saltare questo step.** La PR è la consegna ufficiale del lavoro.  
+Senza PR, Davide non può vedere né approvare il lavoro.
 
 ```bash
 gh pr create \
@@ -183,6 +190,8 @@ Risolve #<N>
 - ✅ <N> test passati
 - ✅ Nessuna regressione"
 ```
+
+Copia l'URL della PR appena creata — ti serve per il prossimo step.
 
 ---
 
@@ -224,8 +233,9 @@ Lo stato è indicato dalla colonna Kanban.
 - [ ] PROJECT.md aggiornato (version + CI Status + Backlog + timestamp)
 - [ ] Versione allineata in pubspec.yaml / package.json
 - [ ] Commit convenzionale con `Closes #N`
-- [ ] Branch pushato
-- [ ] PR aperta con body descrittivo (AC soddisfatti esplicitati)
+- [ ] ⚠️ Branch pushato (`git push -u origin <branch>`) — OBBLIGATORIO
+- [ ] ⚠️ PR aperta con `gh pr create` — OBBLIGATORIO — senza PR il lavoro non esiste
+- [ ] PR body descrittivo (AC soddisfatti esplicitati)
 - [ ] Commento sull'issue
 - [ ] Label NON toccate (solo agente + progetto rimangono)
 

--- a/skills/issue-start/SKILL.md
+++ b/skills/issue-start/SKILL.md
@@ -33,7 +33,22 @@ Capisci:
 
 ---
 
-## STEP 2 — Checkout branch
+## STEP 2 — Aggiorna submodule .workflow
+
+**Prima di toccare qualsiasi codice**, assicurati che il submodule `.workflow` sia all'ultima versione disponibile:
+
+```bash
+cd <repo-locale>
+git submodule update --init --remote .workflow
+```
+
+Questo garantisce che CLAUDE.md, AGENTS.md e tutte le skill che leggi siano aggiornate all'ultima versione del workflow del team.
+
+> ⚠️ Se `.workflow` non è presente o non è inizializzato, esegui prima il setup del progetto.
+
+---
+
+## STEP 3 — Checkout branch
 
 ```bash
 cd <repo-locale>
@@ -53,7 +68,7 @@ gh issue view <N> --repo <owner/repo> --comments
 
 ---
 
-## STEP 3 — Sposta card → In Progress
+## STEP 4 — Sposta card → In Progress
 
 **Project ID**: `PVT_kwHODSTPQM4BP1Xp`
 **Status Field ID**: `PVTSSF_lAHODSTPQM4BP1Xpzg-INlw`
@@ -85,7 +100,7 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
 
 ---
 
-## STEP 4 — Leggi il contesto del progetto
+## STEP 5 — Leggi il contesto del progetto
 
 ```bash
 cat PROJECT.md          # versione, stack, stato, backlog
@@ -99,7 +114,7 @@ Tieni PROJECT.md come riferimento attivo per tutto il lavoro.
 
 ---
 
-## STEP 5 — Esplora il codice rilevante
+## STEP 6 — Esplora il codice rilevante
 
 - Cerca i file correlati all'issue (widget, service, provider, datasource...)
 - Leggi i test esistenti — ti dicono cosa "corretto" significa
@@ -110,6 +125,7 @@ Tieni PROJECT.md come riferimento attivo per tutto il lavoro.
 ## ✅ Checklist pre-codice
 
 - [ ] Issue letta e AC chiari
+- [ ] Submodule `.workflow` aggiornato all'ultima versione (`git submodule update --init --remote .workflow`)
 - [ ] Branch creato e aggiornato da master
 - [ ] Card Kanban → In Progress
 - [ ] PROJECT.md letto


### PR DESCRIPTION
## Fix

### issue-start
- Aggiunto **STEP 2** obbligatorio: \git submodule update --init --remote .workflow\
  Garantisce che ogni agente lavori con l'ultima versione del workflow prima di toccare codice
- Rinumerati step conseguenti (3, 4, 5, 6)
- Checklist aggiornata

### issue-done
- STEP 4 (push branch) e STEP 5 (apertura PR) marcati come **OBBLIGATORI** con warning esplicito
- Checklist: push e PR marcati con ⚠️

**Motivazione:** Claude Code ha implementato correttamente finn #22 ma non ha pushato né aperto la PR — la skill non era abbastanza esplicita sull'obbligatorietà di questi step.