### PR TITLE
refactor(workflow): skill leggera + Step 0 verifica versione online

### DIFF
--- a/CLAUDIO_MEMORY_NOTE.md
+++ b/CLAUDIO_MEMORY_NOTE.md
@@ -1,0 +1,21 @@
+# Nota per MEMORY.md di Claudio
+
+Aggiungere questa sezione in MEMORY.md:
+
+---
+
+## ⚡ REGOLA OPERATIVA GITHUB (OBBLIGATORIA)
+**Prima di qualsiasi operazione GitHub** (creare issue, spostare card, assegnare label, merge, deploy):
+→ **Leggere la skill `8020-workflow`** (nella directory skills/8020-workflow/SKILL.md)
+→ Eseguire lo **Step 0** di verifica aggiornamento workflow
+→ Seguire **alla lettera** le istruzioni per la fase specifica
+→ **NON agire d'impulso** — workflow first, poi esecuzione
+
+**Checklist creazione issue:**
+1. Confermare repo corretto con Davide
+2. NON assegnare label agente (lo fa Claudio su indicazione di Davide)
+3. Creare issue con template corretto
+4. Aggiungere al Kanban in colonna **Backlog**
+5. Colonna **Todo** solo dopo aver assegnato la label agente
+
+Questa regola vale per **Ciccio e Claudio** — nessuno improvvisa su GitHub.

--- a/skills/8020-workflow/SKILL.md
+++ b/skills/8020-workflow/SKILL.md
@@ -1,84 +1,70 @@
 ---
 name: 8020-workflow
-description: "80/20 Solutions team workflow rules for Ciccio. Use when handling GitHub issues, creating/merging PRs, deploying apps, managing branches, writing commit messages, coordinating with Claude Code, triggering CI/CD builds, managing APK releases, processing /reject or /approve commands, moving Kanban board cards, or doing any development or infrastructure task. Ensures Ciccio follows the correct process for the hybrid VPS+PC team system."
+description: "80/20 Solutions team workflow rules for Ciccio and Claudio. Use when handling GitHub issues, creating/merging PRs, deploying apps, managing branches, writing commit messages, coordinating with Claude Code, triggering CI/CD builds, managing APK releases, processing /reject or /approve commands, moving Kanban board cards, or doing any development or infrastructure task. Ensures agents follow the correct process for the hybrid VPS+PC team system."
 ---
 
-# 80/20 Solutions — Workflow (Ciccio)
+# 80/20 Solutions — Workflow
 
-## Ruoli nel team
-- **Davide**: Product owner, testa APK, approva deploy in produzione
-- **Ciccio (VPS)**: Orchestrazione, deploy, infra, monitoring, issue management (label `ciccio`)
-- **Claude Code (PC)**: Development senior, commit, push (label `claude-code`)
-- **Codex (PC)**: Development alternativo, commit, push (label `codex`)
+## ⚙️ STEP 0 — Verifica aggiornamento workflow (OBBLIGATORIO)
 
-## 📋 Board Kanban — 7 colonne
-**GitHub Project**: https://github.com/users/ecologicaleaving/projects/2
+Prima di procedere con qualsiasi operazione GitHub, verifica che il workflow locale sia allineato alla versione online:
 
-| Colonna | Chi sposta | Quando |
-|---------|-----------|--------|
-| `Backlog` | Ciccio | Issue creata, nessun agente assegnato |
-| `Todo` | Ciccio/Davide | Label agente assegnata, pronta per lavorazione |
-| `In Progress` | Ciccio/Agente | Agente ha preso in carico |
-| `Test` | Ciccio | PR aperta + APK/build disponibile — Davide testa |
-| `Review` | Ciccio | Dopo /reject — agente sta rilavorando |
-| `Deploy` | Ciccio | Dopo /approve — deploy prod in corso |
-| `Done` | Ciccio | Issue chiusa, in produzione |
+```bash
+export PATH=$PATH:/root/go/bin
+REMOTE_SHA=$(gh api "repos/ecologicaleaving/workflow/commits?path=skills/8020-workflow&per_page=1" --jq '.[0].sha' 2>/dev/null)
+LOCAL_SHA=$(cat <SKILL_DIR>/.version 2>/dev/null || echo "none")
 
-## Flusso standard
-
-```
-Issue creata → Todo
-  → agente inizia → In Progress
-  → PR aperta + build → Test → notifica Davide
-
-Davide testa:
-  /approve → Deploy → Done (merge → prod)
-  /reject  → Review (agente rilav ora) → Test
+if [ "$REMOTE_SHA" != "$LOCAL_SHA" ]; then
+  echo "⚠️ Workflow aggiornato online — notifica Davide prima di procedere"
+fi
 ```
 
-## Quando Ciccio riceve /reject
-1. Aggiungi commento GitHub con feedback completo
-2. Sposta card: `Test` → `Review` (non toccare le label)
-3. Lavora il fix → quando pronto → sposta card: `Review` → `Test`
-4. Notifica Davide con nuovo APK/link
+Dove `<SKILL_DIR>` è la directory locale di questa skill.
 
-## Quando Ciccio riceve /approve
-1. Mergia PR su master
-2. Sposta card: `Test` → `Deploy`
-3. Deploya in produzione
-4. Sposta card: `Deploy` → `Done`, chiudi issue
-5. Notifica Davide con link prod
+- **Se aggiornato online** → notifica Davide e chiedi se sincronizzare prima di procedere
+- **Se allineato** → prosegui con l'operazione richiesta
 
-## Quando Ciccio fa deploy test (dopo PR aperta)
-1. Build/APK disponibile (CI verde)
-2. Sposta card: `In Progress` → `Test`
-3. Notifica Davide con link APK/URL test
+---
 
-## Regole fondamentali
-- **Mai committare su master/main** — sempre feature branch + PR
-- **PROJECT.md** va aggiornato ad ogni issue completata (version bump + DONE)
-- **APK test**: `https://apps.8020solutions.org/downloads/test/`
-- **ciccio-notify**: `/usr/local/bin/ciccio-notify` per notifiche da CI
-- **Deploy key**: `/root/.ssh/github-actions-deploy`
+## 🗺️ INDICE OPERAZIONI — Leggi solo il file che ti serve
 
-## Labels sistema
-Le issue usano **sole due label**:
-1. **Label progetto** — nome del progetto (es. `beachref`, `finn`)
-2. **Label agente** — chi lavora l'issue (`ciccio`, `claude-code`, `codex`)
+| Operazione | File da leggere |
+|-----------|----------------|
+| Creare una issue | `references/CREATE_ISSUE.md` |
+| Avviare lavorazione (assegnare agente) | `references/ISSUE_START.md` |
+| Deploy su ambiente test | `references/DEPLOY_TEST.md` |
+| /reject da Davide | `references/REJECT.md` |
+| /approva da Davide → prod | `references/APPROVE_DEPLOY.md` |
+| Kanban: colonne e regole | `references/KANBAN.md` |
+| Branch e commit | `references/BRANCH_STRATEGY.md` |
+| Convenzioni commit | `references/COMMIT_CONVENTIONS.md` |
 
-| Label | Significato |
-|-------|-------------|
-| `ciccio` | Ciccio (VPS) — routing obbligatorio |
-| `claude-code` | Claude Code (PC) — routing obbligatorio |
-| `codex` | Codex (PC) — routing obbligatorio |
+---
 
-**Regole:**
-- Le label di stato (`in-progress`, `review-ready`, `deployed-test`, `needs-fix`) NON si usano — lo stato è indicato dalla colonna Kanban
-- Label agente NON viene mai rimossa durante la lavorazione
-- VPS skippa sempre issue con `claude-code` o `codex`
+## 👥 Ruoli (riferimento rapido)
 
-## Riferimenti completi
-- `references/WORKFLOW_CICCIO.md` — procedure complete Ciccio
-- `references/WORKFLOW_CLAUDE_CODE.md` — workflow Claude Code (coordinamento)
-- `references/BRANCH_STRATEGY.md` — git branching
-- `references/COMMIT_CONVENTIONS.md` — formato commit
+| Chi | Cosa fa |
+|-----|---------|
+| **Davide** | Product owner, approva, testa |
+| **Claudio (PC)** | Assegna agente, lancia lavorazione, supervisiona dev |
+| **Ciccio (VPS)** | Crea issue, Kanban, deploy, infra |
+| **Claude Code / Codex** | Sviluppo, commit, push |
+
+## 🏷️ Label agente (riferimento rapido)
+
+- `agent:claude-code` — Claude Code (PC)
+- `agent:ciccio` — Ciccio (VPS)
+- `agent:codex` — Codex (PC)
+- **MAI assegnare label agente senza indicazione di Davide**
+
+## 📋 Kanban colonne (riferimento rapido)
+
+| Colonna | Quando |
+|---------|--------|
+| `Backlog` | Issue creata, **nessun agente assegnato** |
+| `Todo` | Label agente assegnata da Claudio |
+| `In Progress` | Agente in lavorazione |
+| `Test` | Build/APK disponibile — Davide testa |
+| `Review` | Dopo /reject |
+| `Deploy` | Dopo /approva — deploy prod in corso |
+| `Done` | In produzione, issue chiusa |

--- a/skills/8020-workflow/references/APPROVE_DEPLOY.md
+++ b/skills/8020-workflow/references/APPROVE_DEPLOY.md
@@ -1,0 +1,37 @@
+# APPROVE_DEPLOY.md — Procedura /approva → deploy produzione
+
+## Trigger
+Davide scrive: `/approva #<N>` oppure `/merge #<N>`
+
+## Regola d'oro
+L'approvazione esplicita di Davide è sufficiente. **Non verificare prerequisiti**, non bloccarsi su stati intermedi.
+
+## Procedura
+
+1. **Merge PR su master**
+```bash
+export PATH=$PATH:/root/go/bin
+gh pr merge <PR_N> --repo ecologicaleaving/<REPO> --merge --delete-branch
+```
+
+2. **Sposta card: `Test` → `Deploy`**
+→ Vedi `KANBAN.md`
+
+3. **Deploy in produzione**
+→ Vedi `DEPLOY_PROD.md` per la procedura specifica per repo
+
+4. **Sposta card: `Deploy` → `Done`**
+→ Vedi `KANBAN.md`
+
+5. **Chiudi la issue**
+```bash
+gh issue close <N> --repo ecologicaleaving/<REPO>
+```
+
+6. **Aggiorna PROJECT.md** nel repo con version bump + sezione DONE
+
+7. **Notifica Davide**
+```
+🚀 #<N> live in produzione!
+🔗 <URL prod>
+```

--- a/skills/8020-workflow/references/CREATE_ISSUE.md
+++ b/skills/8020-workflow/references/CREATE_ISSUE.md
@@ -1,0 +1,80 @@
+# CREATE_ISSUE.md — Procedura creazione issue
+
+## Checklist OBBLIGATORIA (prima di creare)
+
+**Chiedi a Davide se non è già specificato:**
+1. ✅ Repo corretto? (conferma sempre)
+2. ✅ Tipo: bug / feature / improvement / question?
+3. ✅ Descrizione chiara con comportamento attuale vs atteso?
+
+**Non chiedere:**
+- Agente da assegnare → NON di tua competenza (lo fa Claudio)
+- Priorità → Davide la gestisce con il Kanban
+
+---
+
+## Procedura
+
+### 1. Crea la issue su GitHub
+```bash
+gh issue create \
+  --repo ecologicaleaving/<REPO> \
+  --title "<TITOLO>" \
+  --body "<CORPO>"
+```
+
+**Corpo issue — struttura minima:**
+```markdown
+## 📋 Descrizione
+[Cosa deve fare / qual è il problema]
+
+## 🔧 Comportamento attuale
+[Solo per bug]
+
+## 🎯 Comportamento atteso / Requisiti
+[Cosa deve succedere]
+
+## ✅ Acceptance Criteria
+- [ ] AC1: ...
+- [ ] AC2: ...
+```
+
+### 2. NON assegnare label agente
+La label agente (`agent:claude-code`, `agent:ciccio`, `agent:codex`) viene assegnata da Claudio su indicazione di Davide quando si avvia la lavorazione.
+
+### 3. Aggiungi al Kanban in colonna **Backlog**
+```bash
+export PATH=$PATH:/root/go/bin
+
+# Aggiungi al project
+ITEM_ID=$(gh project item-add 2 --owner ecologicaleaving \
+  --url https://github.com/ecologicaleaving/<REPO>/issues/<N> \
+  --format json | jq -r '.id')
+
+# Imposta colonna Backlog
+gh project item-edit \
+  --project-id PVT_kwHODSTPQM4BP1Xp \
+  --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHODSTPQM4BP1Xpzg-INlw \
+  --single-select-option-id 2ab61313
+```
+
+### 4. Notifica Davide
+```
+✅ Issue creata: <REPO>#<N> — <TITOLO>
+📋 Kanban: Backlog
+🔗 <URL>
+```
+
+---
+
+## IDs di riferimento Kanban
+- **Project ID**: `PVT_kwHODSTPQM4BP1Xp`
+- **Field ID (Status)**: `PVTSSF_lAHODSTPQM4BP1Xpzg-INlw`
+- **Backlog**: `2ab61313`
+- **Todo**: `f75ad846`
+- **In Progress**: `47fc9ee4`
+- **Test**: `1d6a37f9`
+- **Review**: `03f548ab`
+- **Deploy**: `37c4aa50`
+- **Done**: `98236657`

--- a/skills/8020-workflow/references/KANBAN.md
+++ b/skills/8020-workflow/references/KANBAN.md
@@ -1,0 +1,41 @@
+# KANBAN.md — Colonne e regole
+
+## Colonne
+
+| Colonna | Option ID | Chi sposta | Quando |
+|---------|-----------|-----------|--------|
+| `Backlog` | `2ab61313` | Ciccio | Issue creata, **nessuna label agente** |
+| `Todo` | `f75ad846` | Claudio | Label agente assegnata da Claudio |
+| `In Progress` | `47fc9ee4` | Ciccio/Agente | Agente ha preso in carico |
+| `Test` | `1d6a37f9` | Ciccio | Build/APK disponibile — Davide testa |
+| `Review` | `03f548ab` | Ciccio | Dopo /reject — agente in rework |
+| `Deploy` | `37c4aa50` | Ciccio | Dopo /approva — deploy prod in corso |
+| `Done` | `98236657` | Ciccio | In produzione, issue chiusa |
+
+## Spostare una card
+
+```bash
+gh project item-edit \
+  --project-id PVT_kwHODSTPQM4BP1Xp \
+  --id <ITEM_ID> \
+  --field-id PVTSSF_lAHODSTPQM4BP1Xpzg-INlw \
+  --single-select-option-id <OPTION_ID>
+```
+
+## Trovare l'ITEM_ID di una issue
+
+```bash
+gh project item-list 2 --owner ecologicaleaving --format json | \
+  python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for item in data['items']:
+    if item.get('content', {}).get('number') == <N> and '<REPO>' in item.get('repository',''):
+        print(item['id'])
+"
+```
+
+## Regole fondamentali
+- **Backlog → Todo**: solo Claudio, dopo aver assegnato label agente
+- **Label agente NON si rimuove** mai durante la lavorazione
+- **Lo stato è la colonna**, non le label (no label `in-progress`, `review-ready`, ecc.)

--- a/skills/8020-workflow/references/REJECT.md
+++ b/skills/8020-workflow/references/REJECT.md
@@ -1,0 +1,23 @@
+# REJECT.md — Procedura /reject
+
+## Trigger
+Davide scrive: `/reject #<N> "feedback"`
+
+## Procedura
+
+1. **Aggiungi commento sulla issue GitHub** con il feedback completo
+```bash
+gh issue comment <N> --repo ecologicaleaving/<REPO> \
+  --body "## 🔄 Rework richiesto\n\n**Feedback Davide:** <FEEDBACK>\n\n**Data:** $(date -u '+%Y-%m-%d %H:%M UTC')"
+```
+
+2. **Sposta card: `Test` → `Review`** (NON toccare le label)
+→ Vedi `KANBAN.md` per il comando
+
+3. **In base alla label agente:**
+   - `agent:ciccio` → spawna subagente con feedback come contesto, lavora il fix
+   - `agent:claude-code` → notifica Davide: "⚠️ Issue #N richiede fix da Claude Code — riaprire sessione con branch `feature/issue-N`"
+   - `agent:codex` → trigger codex-monitor con contesto feedback
+
+4. Quando fix completato → sposta card: `Review` → `Test`
+5. Notifica Davide con nuovo APK/link test


### PR DESCRIPTION
## 📋 Cosa cambia

### SKILL.md — ora leggero (~60 righe)
- **Step 0 obbligatorio**: verifica SHA remoto vs locale prima di ogni operazione GitHub
- Se il workflow online è più recente → notifica Davide prima di procedere
- Solo indice operazioni + riferimento rapido ruoli/label/kanban

### Reference files separati (leggi solo quello che ti serve)
- `CREATE_ISSUE.md` — checklist + procedura completa creazione issue
- `KANBAN.md` — colonne, IDs, comandi per spostare card
- `REJECT.md` — procedura /reject
- `APPROVE_DEPLOY.md` — procedura /approva → deploy produzione

### CLAUDIO_MEMORY_NOTE.md
Testo pronto da incollare in MEMORY.md di Claudio — regola operativa GitHub obbligatoria.

## ✅ Obiettivo
Ciccio e Claudio seguono il workflow alla lettera senza sovraccaricare il contesto con muri di testo.