### PR TITLE
feat: agent monitor integrato in issue-start e issue-implement

### DIFF
--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** Piano approvato, agente in fase di implementazione  
 **Agente:** Claudio (supervisione) + Claude Code / Codex (esecuzione)  
-**Versione:** 2.0.0
+**Versione:** 2.1.0
 
 ---
 
@@ -130,3 +130,84 @@ L'agente deve rispettare:
 - Niente commit su `main`/`master`
 - Niente `.env`, config sensibili, file di debug
 - `PROJECT.md` aggiornato prima del push
+
+---
+
+## 🔍 Agent Monitor (obbligatorio durante implementazione)
+
+Dopo ogni `exec background` su un agente, avvia subito il monitor leggero.
+Non aspettare — il monitor deve girare in parallelo all'agente per tutta la durata della lavorazione.
+
+**Obiettivo:** ricevere notifiche proattive su checkpoint, errori e completamento, con costo token minimo.
+
+### Come funziona
+
+- Loop ogni 60s: legge output nuovo del processo
+- Keyword matching senza LLM (zero token per la maggior parte dei check)
+- Solo su output rilevante → spawn Haiku per summary (micro-costo)
+- Si auto-termina quando il processo finisce
+
+### Avvio monitor (PowerShell — Windows)
+
+```powershell
+$sessionId = "SESSION_ID"
+$issueN = "ISSUE_N"
+$repo = "REPO"
+$lastOffset = 0
+$silentMinutes = 0
+$keywords = @("error", "failed", "fail", "exception", "bloccato", "blocked", "?", "ask", "done", "completed", "finished", "push", "checkpoint", "CP")
+
+while ($true) {
+    Start-Sleep -Seconds 60
+    $silentMinutes++
+
+    # Controlla se il processo è ancora vivo
+    $status = openclaw process poll --session $sessionId 2>&1
+    $alive = $status -notmatch "exited|not found|No session"
+
+    # Leggi nuovo output
+    $log = openclaw process log --session $sessionId --offset $lastOffset 2>&1
+    if ($log) {
+        $lastOffset += ($log | Measure-Object -Line).Lines
+        $silentMinutes = 0
+
+        # Keyword match (zero LLM)
+        $hit = $keywords | Where-Object { $log -match $_ }
+        if ($hit) {
+            $summary = if ($log.Length -gt 500) {
+                $log | claude --model claude-haiku-4-5 --print "Riassumi in max 2 righe cosa sta succedendo all'agente:" 2>&1
+            } else {
+                $log.Trim()
+            }
+            openclaw system event --text "👀 [Issue #$issueN/$repo] $summary" --mode now
+        }
+    }
+
+    # Silenzio > 10 min → anomalia potenziale
+    if ($silentMinutes -ge 10 -and $alive) {
+        openclaw system event --text "⚠️ [Issue #$issueN/$repo] Agente silenzioso da 10+ minuti. Verificare." --mode now
+        $silentMinutes = 0
+    }
+
+    # Processo terminato → notifica finale e stop
+    if (-not $alive) {
+        openclaw system event --text "🏁 [Issue #$issueN/$repo] Agente terminato. Controlla output e commenti sulla issue." --mode now
+        break
+    }
+}
+```
+
+### Regole token
+
+| Caso | LLM usato | Costo |
+|------|-----------|-------|
+| Nessun keyword trovato | Nessuno | 0 token |
+| Keyword trovato, output < 500 chars | Nessuno | 0 token |
+| Keyword trovato, output ≥ 500 chars | Haiku | Micro |
+| Silenzio > 10 min | Nessuno | 0 token |
+
+### ⚠️ Note
+
+- Non usare modelli pesanti (Sonnet/Opus) per il monitor
+- Il monitor non interagisce mai con l'agente, solo osserva
+- Su Linux/VPS (Ciccio): sostituire la sintassi PowerShell con bash equivalente

--- a/skills/issue-start/SKILL.md
+++ b/skills/issue-start/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** Claudio avvia la fase di piano su una issue  
 **Agente:** Claudio  
-**Versione:** 2.0.0
+**Versione:** 2.1.0
 
 ---
 
@@ -122,3 +122,83 @@ mutation {
 📌 <summary piano in 2-3 righe>
 ⏭️ Agente al lavoro sull'implementazione
 ```
+
+### Step 7 — Avvia Agent Monitor (obbligatorio)
+
+Dopo aver lanciato l'agente in background, avvia subito il monitor leggero.
+Vedi sezione **Agent Monitor** in fondo a questa skill.
+
+---
+
+## 🔍 Agent Monitor
+
+Dopo ogni `exec background` su un agente (research o implementazione), avvia questo monitor.
+
+**Obiettivo:** ricevere notifiche proattive senza polling manuale, con costo token minimo.
+
+### Come funziona
+
+- Loop ogni 60s: legge output nuovo del processo con `process log`
+- Keyword matching senza LLM (zero token per la maggior parte dei check)
+- Solo su output rilevante → spawn Haiku per summary (micro-costo)
+- Si auto-termina quando il processo finisce
+
+### Avvio monitor (PowerShell — Windows)
+
+```powershell
+# Avvia in background subito dopo exec background dell'agente
+# Sostituisci SESSION_ID e ISSUE_N con i valori reali
+
+$sessionId = "SESSION_ID"
+$issueN = "ISSUE_N"
+$repo = "REPO"
+$lastOffset = 0
+$keywords = @("error", "failed", "fail", "exception", "bloccato", "blocked", "?", "ask", "done", "completed", "finished", "push")
+
+while ($true) {
+    Start-Sleep -Seconds 60
+
+    # Controlla se il processo è ancora vivo
+    $status = openclaw process poll --session $sessionId 2>&1
+    $alive = $status -notmatch "exited|not found|No session"
+
+    # Leggi nuovo output
+    $log = openclaw process log --session $sessionId --offset $lastOffset 2>&1
+    if ($log) {
+        $lastOffset += ($log | Measure-Object -Line).Lines
+
+        # Keyword match (zero LLM)
+        $hit = $keywords | Where-Object { $log -match $_ }
+        if ($hit) {
+            # Output rilevante → notifica (Haiku per summary se output lungo)
+            $summary = if ($log.Length -gt 500) {
+                # Spawn Haiku solo se necessario
+                $log | claude --model claude-haiku-4-5 --print "Riassumi in max 2 righe cosa sta succedendo all'agente:" 2>&1
+            } else {
+                $log.Trim()
+            }
+            openclaw system event --text "👀 [Issue #$issueN] Agente: $summary" --mode now
+        }
+    }
+
+    # Processo terminato → notifica finale e stop
+    if (-not $alive) {
+        openclaw system event --text "🏁 [Issue #$issueN/$repo] Agente terminato. Controlla output." --mode now
+        break
+    }
+}
+```
+
+### Regole token
+
+| Caso | LLM usato | Costo |
+|------|-----------|-------|
+| Nessun keyword trovato | Nessuno | 0 token |
+| Keyword trovato, output < 500 chars | Nessuno | 0 token |
+| Keyword trovato, output ≥ 500 chars | Haiku | Micro |
+
+### ⚠️ Note
+
+- Non usare modelli pesanti (Sonnet/Opus) per il monitor
+- Se il processo non risponde per >10 min → notifica Davide
+- Il monitor non interagisce mai con l'agente, solo osserva


### PR DESCRIPTION
## Cosa cambia

Aggiunge la sezione **Agent Monitor** obbligatoria nelle skill \issue-start\ e \issue-implement\.

### Problema
Claudio doveva fare polling manuale per sapere cosa stava facendo l'agente. Nessuna notifica proattiva durante le lavorazioni.

### Soluzione
Un loop PowerShell leggero che gira in background in parallelo all'agente:
- Check ogni 60s via \process log\
- Keyword matching senza LLM (zero token nella maggior parte dei check)
- Spawn **Haiku** solo su output rilevante > 500 chars (micro-costo)
- Notifica automatica se agente silenzioso > 10 min
- Si auto-termina quando il processo finisce

### Token budget
| Caso | LLM | Costo |
|------|-----|-------|
| Nessun keyword | Nessuno | 0 |
| Keyword + output corto | Nessuno | 0 |
| Keyword + output lungo | Haiku | Micro |

### File modificati
- \skills/issue-start/SKILL.md\ → v2.1.0
- \skills/issue-implement/SKILL.md\ → v2.1.0

### Note
- Sintassi PowerShell per Windows (Claudio). Ciccio su VPS dovrà adattare in bash.