### PR TITLE
feat: deploy-test CI pipeline + check sistema test in issue-start

### DIFF
--- a/skills/issue-deploy-test/SKILL.md
+++ b/skills/issue-deploy-test/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** Davide autorizza il deploy in test (dopo PR in Test)  
 **Agente:** Ciccio  
-**Versione:** 2.0.0
+**Versione:** 2.1.0
 
 ---
 
@@ -10,68 +10,180 @@
 
 Deployare il branch della issue sull'ambiente test e notificare Davide con il link per testare.
 
+Il deploy test segue **due modalità** in base al tipo di progetto:
+
+| Tipo progetto | Modalità deploy |
+|---------------|----------------|
+| Web (Next.js, React, Vite) | **CI pipeline** — GitHub Actions builda e deploya via rsync sul VPS |
+| Flutter APK | **Diretto** — Ciccio deploya l'APK dal branch |
+
 ---
 
-## Procedura
+## Procedura — Progetti Web con CI pipeline
 
-### Step 1 — Recupera info dalla PR
-
-```bash
-# Trova la PR aperta per la issue
-gh pr list --repo ecologicaleaving/<repo> --state open \
-  --json number,headRefName,url | jq '.[] | select(.headRefName | contains("issue-N"))'
-```
-
-### Step 2 — Pull branch e build
+### Step 1 — Verifica CI pipeline attiva
 
 ```bash
-cd /var/www/<repo>
-git fetch origin feature/issue-N-slug
-git checkout feature/issue-N-slug
-git pull origin feature/issue-N-slug
-
-# Build in base al tipo di progetto
-# Flutter web:
-# flutter build web --release
-
-# Node/React:
-# npm install && npm run build
-
-# Copia in webroot test
+gh api repos/ecologicaleaving/<repo>/contents/.github/workflows/deploy.yml 2>/dev/null \
+  | jq -r '.content' | base64 -d | grep -q "rsync\|ssh" && echo "CI pipeline presente" || echo "CI pipeline assente"
 ```
 
-### Step 3 — Deploy su test
+Se la pipeline è assente → passa alla procedura **Deploy manuale** (sezione sotto).
 
-Il sottodominio test segue il pattern: `test-<repo>.8020solutions.org`
+### Step 2 — Verifica GitHub Secrets configurati
+
+I secrets necessari per la CI variano per progetto. Controlla quali mancano:
 
 ```bash
-# Esempio per app web
-cp -r build/ /var/www/test-<repo>/
-nginx -s reload
+# Lista secrets configurati nel repo
+gh secret list --repo ecologicaleaving/<repo>
 ```
 
-### Step 4 — Aggiorna label
+**Secrets infra VPS (comuni a tutti i web project):**
+- `VPS_SSH_KEY` — chiave SSH privata per deploy
+- `VPS_HOST` — IP VPS (46.225.60.101)
+- `VPS_USER` — utente SSH (root)
+- `CLOUDFLARE_ZONE_ID` — ID zona Cloudflare
+- `CLOUDFLARE_API_TOKEN` — token API Cloudflare
+
+**Secrets specifici per progetto** (recupera da issue o chiedi a Davide):
+- Variabili `NEXT_PUBLIC_*`, chiavi API, URL Supabase, ecc.
+
+Se mancano secrets infra VPS → aggiungili con i valori standard (vedi MEMORY.md).
+Se mancano secrets specifici progetto → chiedi a Davide prima di procedere:
+```
+⚠️ [Issue #N] Deploy test bloccato — secrets mancanti
+📋 Mancano: NEXT_PUBLIC_SUPABASE_ANON_KEY, NEXT_PUBLIC_SITE_URL
+❓ Puoi fornirli per procedere?
+```
+
+### Step 3 — Aggiungi secrets mancanti
 
 ```bash
-gh issue edit <N> --repo ecologicaleaving/<repo> \
-  --add-label "deployed-test"
+# Aggiungi secret VPS (esempio)
+gh secret set VPS_HOST --repo ecologicaleaving/<repo> --body "46.225.60.101"
+gh secret set VPS_USER --repo ecologicaleaving/<repo> --body "root"
+gh secret set VPS_SSH_KEY --repo ecologicaleaving/<repo> < ~/.ssh/id_rsa
+
+# Secret specifico progetto
+gh secret set NEXT_PUBLIC_SUPABASE_ANON_KEY --repo ecologicaleaving/<repo> --body "<valore>"
 ```
 
-### Step 5 — Notifica Davide
+### Step 4 — Triggera la CI sul branch
+
+Se la CI non è partita automaticamente dopo il push del branch:
+
+```bash
+# Verifica ultimo run CI
+gh run list --repo ecologicaleaving/<repo> --branch feature/issue-N-slug --limit 3
+
+# Se nessun run → triggera manualmente
+gh workflow run deploy.yml --repo ecologicaleaving/<repo> --ref feature/issue-N-slug
+```
+
+### Step 5 — Monitora il run CI
+
+```bash
+# Attendi completamento
+gh run watch --repo ecologicaleaving/<repo>
+
+# Oppure controlla stato
+gh run list --repo ecologicaleaving/<repo> --branch feature/issue-N-slug --limit 1 \
+  --json status,conclusion,url | jq '.[0]'
+```
+
+**Se CI fallisce:**
+1. Leggi il log: `gh run view <run-id> --repo ecologicaleaving/<repo> --log-failed`
+2. Se errore secrets → torna a Step 3
+3. Se errore build → notifica Claudio con dettaglio errore
+4. Non procedere finché CI non è verde
+
+### Step 6 — Verifica deploy avvenuto
+
+La CI deploya automaticamente su `test-<repo>.8020solutions.org/b/<branch-slug>`.
+
+```bash
+# Verifica HTTP
+SLUG=$(echo "feature/issue-N-slug" | sed 's|/|-|g' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+curl -s -o /dev/null -w "%{http_code}" "https://test-<repo>.8020solutions.org/b/${SLUG}/"
+```
+
+### Step 7 — Aggiorna label e Kanban
+
+```bash
+# Label deployed-test (crea se non esiste)
+gh label create "deployed-test" --repo ecologicaleaving/<repo> --color "#0075ca" 2>/dev/null || true
+gh issue edit <N> --repo ecologicaleaving/<repo> --add-label "deployed-test"
+
+# Kanban → Test (singleSelectOptionId: "9c813e6b")
+ITEM_ID=$(gh project item-list 2 --owner ecologicaleaving --format json \
+  | jq -r '.items[] | select(.content.number == <N> and (.content.repository.name == "<repo>")) | .id')
+
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwHODSTPQM4BP1Xp"
+    itemId: "'$ITEM_ID'"
+    fieldId: "PVTSSF_lAHODSTPQM4BP1Xpzg-INlw"
+    value: { singleSelectOptionId: "9c813e6b" }
+  }) { projectV2Item { id } }
+}'
+```
+
+### Step 8 — Notifica Davide
 
 ```
 🧪 [Issue #N] Deploy test ok
-🔗 https://test-<repo>.8020solutions.org
+🔗 https://test-<repo>.8020solutions.org/b/<branch-slug>/
 📋 Cosa testare:
-  - <AC 1>
-  - <AC 2>
-  - <AC 3>
+  - <AC 1 dalla issue>
+  - <AC 2 dalla issue>
+  - <AC 3 dalla issue>
 ```
+
+---
+
+## Procedura — Deploy manuale (no CI pipeline)
+
+Per progetti senza `deploy.yml` (es. Flutter APK, static sites semplici):
+
+### Step 1 — Pull branch e build
+
+```bash
+cd /root/<repo>-deploy  # o clona se non esiste
+git fetch origin
+git checkout feature/issue-N-slug
+git pull origin feature/issue-N-slug
+
+# Node/React/Next.js:
+npm ci && npm run build
+# → output in out/ o build/
+
+# Flutter web:
+flutter build web --release
+# → output in build/web/
+```
+
+### Step 2 — Deploy su test
+
+```bash
+# Web app
+rsync -avz --delete out/ /var/www/test-<repo>/
+nginx -s reload
+
+# APK Flutter
+cp build/app/outputs/flutter-apk/app-release.apk /var/www/test-<repo>/download/<repo>.apk
+```
+
+### Step 3 — Aggiorna label e notifica Davide
+
+Stesso Step 7 e Step 8 della procedura CI.
 
 ---
 
 ## Note
 
-- Il deploy test non modifica mai la produzione
-- Se il build fallisce → notifica Claudio che notifica Davide
-- Ambiente test può essere sovrascritto da deploy successivi
+- Il deploy test **non modifica mai la produzione**
+- Ambiente test può essere sovrascritto da deploy successivi sullo stesso branch
+- I secrets infra VPS (`VPS_SSH_KEY`, `VPS_HOST`, `VPS_USER`, `CLOUDFLARE_*`) sono identici per tutti i repo — Ciccio li ha disponibili
+- Secrets specifici progetto (Supabase, API keys) vanno chiesti a Davide se non disponibili

--- a/skills/issue-start/SKILL.md
+++ b/skills/issue-start/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** Claudio avvia la fase di piano su una issue  
 **Agente:** Claudio  
-**Versione:** 2.1.0
+**Versione:** 2.2.0
 
 ---
 
@@ -13,6 +13,51 @@ Avviare la lavorazione di una issue: lanciare l'agente in modalità research-onl
 ---
 
 ## Procedura
+
+### Step 0 — Verifica sistema test/deploy-test (obbligatorio)
+
+Prima di avviare qualsiasi lavorazione, Claudio verifica che il progetto abbia il sistema test configurato correttamente.
+
+```bash
+REPO="<repo>"
+
+echo "=== CI pipeline ==="
+gh api repos/ecologicaleaving/$REPO/contents/.github/workflows/deploy.yml 2>/dev/null \
+  | jq -r '.content' | base64 -d | grep -q "rsync\|ssh" && echo "✅ CI pipeline presente" || echo "❌ CI pipeline assente"
+
+echo "=== Secrets configurati ==="
+gh secret list --repo ecologicaleaving/$REPO
+
+echo "=== Sottodominio test ==="
+curl -s -o /dev/null -w "HTTP %{http_code}" "https://test-$REPO.8020solutions.org" && echo " — ✅ raggiungibile" || echo " — ❌ non raggiungibile"
+```
+
+**Valutazione:**
+
+| Stato | Azione |
+|-------|--------|
+| ✅ CI presente + secrets ok + sottodominio ok | Procedi con Step 1 |
+| ❌ CI assente ma sottodominio ok | Procedi — deploy sarà manuale |
+| ❌ Secrets mancanti (infra VPS) | Segnala a Ciccio per aggiunta prima di procedere |
+| ❌ Secrets mancanti (specifici progetto) | Notifica Davide — blocca finché non li fornisce |
+| ❌ Sottodominio non raggiungibile | Segnala a Ciccio — non bloccare la lavorazione ma avvisa |
+
+**Notifica a Davide se tutto ok:**
+```
+✅ [Issue #N/<repo>] Sistema test verificato
+🔧 CI pipeline: presente / assente
+🔑 Secrets: ok / mancanti: <lista>
+🌐 test-<repo>.8020solutions.org: raggiungibile / non raggiungibile
+```
+
+**Notifica a Davide se bloccante:**
+```
+⚠️ [Issue #N/<repo>] Sistema test non pronto
+📋 Problema: <descrizione>
+❓ Come procedo?
+```
+
+---
 
 ### Step 1 — Sposta card → Todo
 


### PR DESCRIPTION
## Cosa cambia

### Problema
- `issue-deploy-test` descriveva solo un deploy manuale generico — nessuna procedura per progetti web con CI pipeline già configurata
- `issue-start` non verificava mai se il sistema test era pronto prima di avviare una lavorazione (vedi caso maestroweb: PR fatta, deploy richiesto, ma secrets mancanti → fallito)

### Soluzione

**`issue-deploy-test` v2.1.0:**
- Due modalità: **CI pipeline** (Next.js/React con `deploy.yml`) e **manuale** (Flutter APK, static)
- Procedura CI: verifica secrets → aggiungi quelli mancanti → triggera CI → monitora run → verifica deploy → label + notifica
- Secrets infra VPS (comuni a tutti) vs secrets specifici progetto (da Davide se mancano)
- Ciccio non ribuilda mai manualmente se esiste una CI pipeline

**`issue-start` v2.2.0:**
- Step 0 obbligatorio: Claudio verifica CI pipeline, secrets e sottodominio test prima di avviare qualsiasi lavorazione
- Tabella valutazione con azione per ogni caso
- Notifica Davide con stato sistema test

### Perché ora
Caso reale: maestroweb issue #2 — deploy test fallito perché secrets non configurati. Con questa procedura Claudio lo avrebbe rilevato prima di iniziare.

### File modificati
- `skills/issue-deploy-test/SKILL.md` → v2.1.0
- `skills/issue-start/SKILL.md` → v2.2.0