### PR TITLE
fix: solo Claudio modifica la repo workflow

### DIFF
--- a/WORKFLOW_CICCIO.md
+++ b/WORKFLOW_CICCIO.md
@@ -18,6 +18,12 @@ Ciccio è l'orchestratore del team sul VPS. È il punto di conversazione princip
 **NON fa:**
 - Creazione / lavorazione issue → Claudio
 - Lancio agenti Claude Code / Codex → Claudio
+- Modifiche alla repo `ecologicaleaving/workflow` → solo Claudio
+
+> ⚠️ **Regola: la repo workflow è di Claudio**
+> Se noti qualcosa da cambiare nel workflow, segnalalo a Davide.
+> Davide lo gira a Claudio, che farà branch + PR.
+> Non aprire PR né modificare file in `ecologicaleaving/workflow` direttamente.
 
 ---
 

--- a/WORKFLOW_CLAUDIO.md
+++ b/WORKFLOW_CLAUDIO.md
@@ -14,11 +14,17 @@ Claudio è il supervisore del ciclo di vita delle issue sul PC Windows.
 - Lanciare e supervisionare agenti (Claude Code / Codex)
 - Riportare progressi a Davide a ogni checkpoint
 - Verificare la PR finale e notificare Ciccio per il deploy
+- **Manutenzione della repo `ecologicaleaving/workflow`** — unico responsabile di modifiche, PR e merge
 
 **NON fa:**
 - Deploy (né test né produzione) → Ciccio
 - Merge → Ciccio su `/merge`
 - Monitoring automatico in background
+
+> ⚠️ **Regola: solo Claudio modifica la repo workflow**
+> Ciccio non apre PR né modifica file in `ecologicaleaving/workflow`.
+> Per cambiamenti al workflow: Ciccio segnala a Davide → Davide chiede a Claudio → Claudio fa branch + PR.
+> Nessuno improvvisa modifiche al workflow senza passare da Claudio.
 
 ---
 


### PR DESCRIPTION
Aggiunge regola esplicita che la repo \ecologicaleaving/workflow\ è gestita esclusivamente da Claudio.

**Modifiche:**
- \WORKFLOW_CLAUDIO.md\: aggiunta responsabilità manutenzione repo + blocco con regola owner
- \WORKFLOW_CICCIO.md\: aggiunto in 'NON fa' + blocco con regola owner

**Flusso per modifiche al workflow:**
\Ciccio segnala → Davide gira → Claudio fa branch + PR\

Chiude il problema sollevato da Ciccio sulla PR #23.