### PR TITLE
fix: issue-implement version header 2.1.0 -> 2.2.0

### DIFF
--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -1,8 +1,8 @@
-# Skill: issue-implement
+﻿# Skill: issue-implement
 
 **Trigger:** Piano approvato, agente in fase di implementazione  
 **Agente:** Claudio (supervisione) + Claude Code / Codex (esecuzione)  
-**Versione:** 2.1.0
+**Versione:** 2.2.0
 
 ---
 


### PR DESCRIPTION
Header non allineato al contenuto dopo PR #22. Il contenuto era già v2.2.0 (CP4 con checklist CI/secrets/sottodominio/DB), solo l'header riportava 2.1.0. Fix minimale, encoding UTF-8 corretto.