### PR TITLE
refactor: single-agent workflow — rimuovi Claudio e Ciccio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,42 +3,33 @@
 ## Team 8020 Solutions
 
 ### Ruoli
-- **Davide (Boss)**: Decisore finale su tutto, sviluppa in locale
-- **Claude Code (io, PC locale)**: Senior Dev - assiste sviluppo, debug, test locale, code review
-- **Ciccio (OpenClaw agent VPS)**: ORCHESTRATORE - gestisce merge, deploy, VPS, database, infrastruttura
+- **Davide (Boss)**: Decisore finale su tutto — dà comandi, testa, approva/reject
+- **Claude Code (io)**: Agente autonomo — gestisco tutto il ciclo: issue, research, implementazione, PR, merge
 
 ### Coordinamento
-- Per questioni infrastruttura/DB/VPS ci si coordina con Ciccio
+- Azioni infra VPS (env vars, migrazioni DB): le elenca l'agente, le esegue Davide manualmente
+- VPS: 46.225.60.101 — vedi `skills/8020-workflow/references/WORKFLOW_CICCIO.md` per comandi
 
 ## Workflow Operativo (TUTTI i progetti)
 
-### 1. Sviluppo Locale
-- Branch: `feature/nome-feature`
-- Davide sviluppa, io assisto (debugging, test, code review)
-- Quando ready: Davide fa `git push` e dice a Ciccio "deploy su test"
+### Flusso
+1. Davide dà un comando (`/create-issue`, `/issue-validate #N`, `/vai`, `/approva`, `/reject`)
+2. L'agente esegue in autonomia: issue → kanban → implementazione → PR → merge
+3. La CI deploya automaticamente (test dopo push, produzione dopo merge)
 
-### 2. Test Deploy
-- Ciccio gestisce: build -> deploy test-*.8020solutions.org
-- Ciccio notifica Davide: "Test ready: [link]"
-
-### 3. Production
-- Davide: "Test OK, vai in produzione"
-- Ciccio gestisce: merge to master -> build prod -> deploy production
-
-## Branch Strategy
-- `feature/nome-feature` -> sviluppo (qui lavoriamo io e Davide)
-- `test` -> ambiente test
-- `master` -> produzione
+### Branch Strategy
+- `feature/issue-N-slug` -> sviluppo
+- `master` -> produzione (CI deploya automaticamente)
 
 ## Il Mio Ruolo (Claude Code)
-- Assistere sviluppo locale, test, code review
-- Quando pronto: Davide fa git push e dice "Ciccio deploy su test"
-- Resto: Ciccio gestisce merge + deploy automatico
+- Gestisco l'intero ciclo di sviluppo senza intermediari
+- Creo issue, valido, pianifco, implemento, apro PR, mergio dopo `/approva`
+- Mi blocco e chiedo a Davide solo su anomalie o decisioni che richiedono il suo giudizio
 
 ## Regole Fondamentali
 - **MAI inventare** informazioni, credenziali, configurazioni o soluzioni se non ho certezza
 - Se ho dubbi, problemi o mi mancano info: lo dico subito a Davide
-- Se serve, chiediamo a Ciccio (che ha accesso a VPS, DB, infrastruttura)
+- **Nessun fix/patch senza autorizzazione esplicita di Davide**
 - Meglio chiedere che fare danni
 
 ## Progetti

--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
-# 80/20 Solutions — Workflow v2.0
+# 80/20 Solutions — Workflow v4.0
 
-**Aggiornato:** 2026-03-20
+**Aggiornato:** 2026-04-13
 
 ---
 
-## 🏗️ Architettura Team
+## 🏗️ Team
 
 ```
-Davide (Telegram)
+Davide (Product Owner)
     │
-    ├──→ Ciccio (VPS) ────── conversazione principale, infra, deploy, /merge
-    │
-    └──→ Claudio (PC) ────── gestione issue, supervisione agenti, supporto sviluppo
-              │
-              ├── Claude Code  (dev agent)
-              └── Codex        (dev agent alternativo)
+    └──→ Agente (Claude Code) — gestisce tutto il ciclo
+              └── research → piano → implementazione → PR → merge
 ```
 
 ---
@@ -38,34 +34,34 @@ Workflow normale per ogni issue (vedi sotto)
 ## 🔄 Flusso Issue (singola)
 
 ```
-Davide descrive → Claudio /create-issue → Backlog
-                                ↓
-                           Claudio avvia piano → Todo
-                                ↓
-                        Piano approvato → InProgress
-                     (agente al lavoro, checkpoint obbligatori)
-                                ↓
-                          PR pronta → Test
-                       (Ciccio deploya in test)
-                                ↓
-                    Davide testa
-                    ├── /approva → Deploy → Ciccio /merge → Done
-                    └── /reject  → Review → rework → Test → loop
+Davide descrive → /create-issue → Backlog
+                        ↓
+               /issue-validate → research + piano → Todo
+                        ↓
+                    /vai → InProgress
+              (agente implementa autonomamente)
+                        ↓
+                 Auto-gate → push → PR → Test
+               (CI deploya su test-<repo>.8020solutions.org)
+                        ↓
+                  Davide testa
+                  ├── /approva → Agente mergia → CI deploya prod → Done
+                  └── /reject  → Review → rework → Test → loop
 ```
 
 ---
 
 ## 📋 Comandi
 
-| Comando | Chi | Cosa fa |
-|---------|-----|---------|
-| `/create-prd` | Davide → Claudio | Crea PRD da idea/brief |
-| `/prd-to-issues` | Davide → Claudio | Genera issue batch da PRD |
-| `/create-issue` | Davide → Claudio | Avvia raccolta singola issue |
-| `/vai` | Davide → Claudio | Dà il via all'agente |
-| `/approva` | Davide → Claudio | Approva PR, card → Deploy |
-| `/reject <feedback>` | Davide → Claudio | Rework con feedback |
-| `/merge #N` | Davide → Ciccio | Merge + deploy produzione |
+| Comando | Chi risponde | Cosa fa |
+|---------|-------------|---------|
+| `/create-prd` | Agente | Crea PRD da idea/brief |
+| `/prd-to-issues` | Agente | Genera issue batch da PRD |
+| `/create-issue` | Agente | Crea issue leggera in Backlog |
+| `/issue-validate #N` | Agente | Research + piano → Todo |
+| `/vai` | Agente | Avvia implementazione |
+| `/approva` | Agente | Mergia PR, deploya prod, chiude issue |
+| `/reject <feedback>` | Agente | Registra feedback, avvia rework |
 
 ---
 
@@ -73,29 +69,29 @@ Davide descrive → Claudio /create-issue → Backlog
 
 ```
 workflow/
-├── config.json                    # Fonte di verità ID Kanban, repos, agenti
-├── README.md                      # Questo file
-├── WORKFLOW_CLAUDIO.md            # Ruolo e workflow Claudio
-├── WORKFLOW_CICCIO.md             # Ruolo e workflow Ciccio
-├── KANBAN_WORKFLOW.md             # Flusso Kanban colonne
-├── BRANCH_STRATEGY.md             # Convenzioni branch (invariato)
-├── COMMIT_CONVENTIONS.md          # Convenzioni commit (invariato)
+├── config.json                       # Fonte di verità ID Kanban, repos
+├── README.md                         # Questo file
+├── WORKFLOW.md                       # Flusso completo, ruoli, fasi
+├── CLAUDE.md                         # Istruzioni agente
 ├── templates/
-│   ├── issue-feature.md           # Template issue feature
-│   ├── issue-bug.md               # Template issue bug
-│   ├── issue-improvement.md       # Template issue improvement
-│   ├── pull_request_template.md   # Template PR
-│   └── reject.md                  # Template sezione rework
+│   ├── CLAUDE.md                     # Template regole agente (da copiare nei repo)
+│   ├── AGENTS.md                     # Stessa cosa in inglese
+│   ├── issue-feature.md              # Template issue feature
+│   ├── issue-bug.md                  # Template issue bug
+│   ├── issue-improvement.md          # Template issue improvement
+│   └── pull_request_template.md      # Template PR
 └── skills/
-    ├── create-prd/SKILL.md        # Conversazione → PRD + PROJECT.md
-    ├── prd-to-issues/SKILL.md     # PRD → issue batch su GitHub
-    ├── create-issue/SKILL.md      # Creazione issue singola strutturata
-    ├── issue-start/SKILL.md       # Avvio piano e lavorazione
-    ├── issue-implement/SKILL.md   # Supervisione implementazione
-    ├── issue-done/SKILL.md        # PR + notifica test
-    ├── issue-reject/SKILL.md      # Gestione reject e rework
-    ├── issue-deploy-test/SKILL.md # Deploy ambiente test (Ciccio)
-    └── issue-deploy-prod/SKILL.md # Merge + deploy produzione (Ciccio)
+    ├── create-issue/SKILL.md         # Fase 1 — creazione issue
+    ├── issue-validate/SKILL.md       # Fase 2 — validazione + piano
+    ├── issue-implement/SKILL.md      # Fase 3 — implementazione
+    ├── issue-pr-ready/SKILL.md       # Fase 4 — PR + notifica
+    ├── issue-approve/SKILL.md        # Fase 5a — merge dopo /approva
+    ├── issue-reject/SKILL.md         # Fase 5b — rework dopo /reject
+    ├── issue-research-rework/SKILL.md # Fase 5b — rework complesso
+    ├── create-prd/SKILL.md           # Creazione PRD
+    ├── prd-to-issues/SKILL.md        # PRD → issue batch
+    ├── security-audit/SKILL.md       # Gate sicurezza pre-push
+    └── preparazione-repo/SKILL.md    # Setup iniziale repo
 ```
 
 ---
@@ -105,10 +101,8 @@ workflow/
 | Label | Significato |
 |-------|-------------|
 | `agent:claude-code` | Assegnata a Claude Code |
-| `agent:codex` | Assegnata a Codex |
-| `agent:ciccio` | Task infra per Ciccio |
 | `in-progress` | Agente al lavoro |
-| `review-ready` | PR pronta |
+| `review-ready` | PR pronta per test Davide |
 | `deployed-test` | Live su test |
 | `needs-fix` | Reject, rework in corso |
 | `deployed-prod` | Live in produzione |
@@ -117,16 +111,15 @@ workflow/
 
 ## 📊 Kanban
 
-**Project:** 80/20 Solutions - Development Hub (#2)  
-**Owner:** ecologicaleaving  
+**Project:** 80/20 Solutions - Development Hub (#2)
+**Owner:** ecologicaleaving
 **IDs:** vedi `config.json`
 
 | Colonna | Significato |
 |---------|-------------|
 | Backlog | Issue creata |
-| Todo | Pronta per piano |
+| Todo | Pronta per lavorazione |
 | InProgress | Agente al lavoro |
 | Test | PR aperta, in test |
 | Review | Rework dopo reject |
-| Deploy | Approvata, in deploy |
-| Done | Completata |
+| Done | Completata, in produzione |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,6 +1,6 @@
 # WORKFLOW.md — 80/20 Solutions Development Workflow
 
-**Versione:** 3.0.0 | **Aggiornato:** 2026-04-03
+**Versione:** 4.0.0 | **Aggiornato:** 2026-04-13
 
 > Fonte di verità unica per il flusso di sviluppo del team.
 > I valori strutturati (ID Kanban, repo, label) stanno in `config.json`.
@@ -12,21 +12,20 @@
 
 | Chi | Ruolo | Cosa fa | Cosa NON fa |
 |-----|-------|---------|-------------|
-| **Davide** | Product Owner | Decide, testa, approva/reject | Non implementa, non deploya |
-| **Claudio** (PC) | Supervisore | Crea issue, lancia agenti, supervisiona, mergia PR | Non scrive codice MAI, non gestisce infra |
-| **Ciccio** (VPS) | Infra & Deploy | Gestisce VPS, DB, domini, azioni infra su richiesta | Non modifica il workflow, non lancia agenti |
-| **Agente** (Sonnet) | Sviluppatore | Research, piano, implementazione, test | Non mergia, non deploya, non decide |
+| **Davide** | Product Owner | Decide, testa, approva/reject, dà i comandi | Non implementa, non deploya |
+| **Agente** (Claude Code) | Sviluppatore autonomo | Tutto il resto: issue, research, piano, implementazione, kanban, PR, merge | Non decide senza autorizzazione di Davide |
 
 > ⚠️ **Regola cardinale:** Nessun fix/patch senza autorizzazione esplicita di Davide.
-> ⚠️ **Repo workflow:** Solo Claudio modifica `ecologicaleaving/workflow`. Ciccio segnala → Davide decide → Claudio implementa.
+> ⚠️ **Repo workflow:** Solo l'agente modifica `ecologicaleaving/workflow` su indicazione di Davide.
 
 ---
 
 ## 🤖 Modello Agente
 
-**Un solo agente Sonnet** (`anthropic/claude-sonnet-4-6`) per l'intero ciclo: research → piano → implementazione.
+**Un solo agente** (`claude-sonnet-4-6` via Claude Code) gestisce l'intero ciclo:
+research → piano → implementazione → PR → merge.
 
-L'agente mantiene il contesto dall'esplorazione al codice — zero passaggi di informazione tra agenti diversi, zero context reload.
+L'agente mantiene il contesto dall'esplorazione al codice — zero passaggi tra agenti diversi.
 
 ---
 
@@ -34,11 +33,11 @@ L'agente mantiene il contesto dall'esplorazione al codice — zero passaggi di i
 
 | Comando | Effetto |
 |---------|---------|
-| `/create-issue` | Claudio raccoglie info e crea issue → Backlog |
-| `/issue-validate #N` | Claudio completa la issue con AC, research, piano → Todo |
-| `/vai` | Claudio avvia implementazione agente |
-| `/approva` | Claudio mergia PR su main → CI deploya automaticamente |
-| `/reject <feedback>` | Claudio registra feedback, rilancia agente in rework |
+| `/create-issue` | Agente raccoglie info e crea issue → Backlog |
+| `/issue-validate #N` | Agente completa la issue con AC, research, piano → Todo |
+| `/vai` | Agente avvia implementazione |
+| `/approva` | Agente mergia PR su main → CI deploya automaticamente |
+| `/reject <feedback>` | Agente registra feedback e rilancia rework |
 
 ---
 
@@ -53,12 +52,12 @@ Davide descrive problema/feature
          ↓
     /vai (Davide)
          ↓
-    FASE 3 — Implementazione (checkpoint) → InProgress
+    FASE 3 — Implementazione (auto-gate) → InProgress
          ↓
     FASE 4 — PR + Deploy test automatico → Test
          ↓
     Davide testa
-    ├── /approva → Claudio mergia → CI deploya prod → Done
+    ├── /approva → Agente mergia → CI deploya prod → Done
     └── /reject  → Rework → loop da Fase 3
 ```
 
@@ -66,7 +65,7 @@ Davide descrive problema/feature
 
 ## FASE 1 — Creazione Issue
 
-**Chi:** Claudio
+**Chi:** Agente
 **Skill:** `create-issue`
 **Kanban:** → Backlog
 
@@ -77,48 +76,48 @@ Issue leggera — i dettagli arrivano nella Fase 2.
 
 ## FASE 2 — Validazione + Piano
 
-**Chi:** Claudio (interattivo con Davide) → Sonnet (research + piano)
+**Chi:** Agente (interattivo con Davide)
 **Skill:** `issue-validate`
 **Kanban:** Backlog → Todo
 
 1. **Domande a Davide** — AC, edge case, dipendenze, note tecniche (una alla volta)
-2. **Verifica deploy** — CI pipeline, secrets, sottodomini (una volta per repo, non ripetere se già verificato)
-3. **Sonnet esplora + pianifica** — un solo agente fa research e piano in un colpo
-4. **Valutazione Claudio** — check formale: AC coperti, scope ok, niente red flag
+2. **Verifica deploy** — CI pipeline, secrets, sottodomini (una volta per repo)
+3. **Esplora + pianifica** — research e piano in un colpo solo
+4. **Auto-validazione** — check formale: AC coperti, scope ok, niente red flag
 5. **Notifica Davide** — piano pronto, aspetta `/vai`
 
-> ⚠️ Claudio NON avvia mai l'implementazione senza `/vai` esplicito.
-> Dopo `/vai`, lo **stesso agente** prosegue con l'implementazione (nessun respawn).
+> ⚠️ L'agente NON avvia mai l'implementazione senza `/vai` esplicito di Davide.
 
 ---
 
 ## FASE 3 — Implementazione
 
-**Chi:** Claudio (supervisione) + stesso Sonnet della Fase 2 (esecuzione)
+**Chi:** Agente
 **Skill:** `issue-implement`
 **Kanban:** Todo → InProgress (dopo `/vai`)
 
-### Checkpoint
+### Auto-gate
 
-L'agente procede in autonomia e si ferma al **gate finale** (pronto per push).
-Se incontra anomalie, si auto-blocca e notifica Claudio.
+L'agente procede in autonomia e si auto-blocca solo su anomalie o al gate finale.
 
 | Momento | Cosa succede |
 |---------|-------------|
-| Dopo `/vai` | Agente implementa in autonomia (no checkpoint intermedi) |
-| Anomalia | Agente si blocca, notifica Claudio → Claudio notifica Davide |
-| **Gate finale** | Agente posta checkpoint: AC verificati, test passati, build ok, security audit ok |
-| Claudio valida | `✅ procedi` (push) oppure `🔴 bloccato` (fix) |
+| Dopo `/vai` | Agente implementa in autonomia |
+| Anomalia | Agente si blocca e notifica Davide |
+| **Gate finale** | Agente verifica: AC ok, test ok, build ok, security audit ok |
+| Gate superato | Agente procede a push + PR automaticamente |
+| Gate fallito | Agente fixa e ripete il gate |
 
-### Notifica a Davide (al gate finale)
+### Notifica a Davide (dopo push + PR)
 
 ```
-✅ [Issue #N] Implementazione completata
+✅ [Issue #N] Implementazione completata, PR aperta
 📌 <summary cosa è stato fatto>
-⏭️ Apro la PR dopo verifica finale
+🔗 <link PR>
+⏭️ Testa su test-<repo>.8020solutions.org
 ```
 
-Anomalia → blocca agente, notifica Davide, aspetta istruzioni.
+Anomalia non risolvibile → blocca, notifica Davide, aspetta istruzioni.
 Più di 5 iterazioni senza convergere → blocco automatico.
 
 ### Security Audit (obbligatorio pre-push)
@@ -130,17 +129,17 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 
 ## FASE 4 — PR + Deploy Test
 
-**Chi:** Claudio (PR) + CI (deploy automatico)
+**Chi:** Agente + CI (deploy automatico)
 **Skill:** `issue-pr-ready`
 **Kanban:** InProgress → Test
 
-1. Claudio verifica checklist pre-PR (AC, test, PROJECT.md, niente file anomali)
-2. Claudio apre PR con summary strutturato
+1. Agente verifica checklist pre-PR (AC, test, PROJECT.md, niente file anomali)
+2. Agente apre PR con summary strutturato
 3. CI deploya automaticamente su `test-<repo>.8020solutions.org`
-4. Bot Telegram notifica Davide con link + AC da verificare
-5. Claudio aggiunge label `review-ready`
+4. Agente aggiunge label `review-ready`
+5. Agente notifica Davide con link e istruzioni di test
 
-### Notifica Davide (con istruzioni di test)
+### Notifica Davide
 
 ```
 ✅ [Issue #N] PR pronta → <link PR>
@@ -159,29 +158,27 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 
 ## FASE 5a — Approvazione
 
-**Chi:** Claudio
+**Chi:** Agente
 **Skill:** `issue-approve`
 **Kanban:** Test → Done
 
-1. Claudio mergia la PR su main: `gh pr merge --merge --delete-branch`
+1. Agente mergia la PR su main: `gh pr merge --merge --delete-branch`
 2. CI deploya automaticamente in produzione
-3. Claudio chiude la issue e aggiunge label `deployed-prod`
-4. Claudio notifica Davide con conferma
-5. **Se servono azioni infra** (env vars, migrazioni DB) → Claudio prepara messaggio per Ciccio, lo propone a Davide prima di inviare
-
-> Se non servono azioni infra → nessun coinvolgimento di Ciccio.
+3. Agente chiude la issue e aggiunge label `deployed-prod`
+4. Agente notifica Davide con conferma
+5. **Se servono azioni infra** (env vars, migrazioni DB) → Agente elenca le azioni da eseguire manualmente e le comunica a Davide
 
 ---
 
 ## FASE 5b — Reject + Rework
 
-**Chi:** Claudio
+**Chi:** Agente
 **Skill:** `issue-reject` (per reject semplici) | `issue-research-rework` (per reject complessi ≥2)
 **Kanban:** Test → Review → InProgress → Test (loop)
 
-1. Claudio registra feedback + risultati test come commento sulla issue
+1. Agente registra feedback + risultati test come commento sulla issue
 2. Label: rimuove `review-ready`, aggiunge `needs-fix`
-3. Rilancia agente con feedback come contesto
+3. Agente rilancia rework con feedback come contesto
 4. Stesso flusso Fase 3 → Fase 4
 5. Loop fino a `/approva`
 
@@ -191,15 +188,12 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 
 | Colonna | Significato | Chi sposta |
 |---------|-------------|------------|
-| **Backlog** | Issue creata | Claudio (create-issue) |
-| **Todo** | Validata, piano pronto, aspetta /vai | Claudio (issue-validate) |
-| **InProgress** | Agente al lavoro | Claudio (dopo /vai) |
-| **Test** | PR aperta, CI ha deployato in test | Claudio (issue-pr-ready) |
-| **Review** | Reject, agente in rework | Claudio (issue-reject) |
-| **Done** | Mergiato, in produzione, chiuso | Claudio (issue-approve) |
-
-> La colonna **Deploy** nel project board non è più usata — Claudio mergia direttamente dopo `/approva`.
-> ID colonne e campo: vedi `config.json`.
+| **Backlog** | Issue creata | Agente (create-issue) |
+| **Todo** | Validata, piano pronto, aspetta /vai | Agente (issue-validate) |
+| **InProgress** | Agente al lavoro | Agente (dopo /vai) |
+| **Test** | PR aperta, CI ha deployato in test | Agente (issue-pr-ready) |
+| **Review** | Reject, rework in corso | Agente (issue-reject) |
+| **Done** | Mergiato, in produzione, chiuso | Agente (issue-approve) |
 
 ### Label
 
@@ -208,7 +202,7 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 | `agent:claude-code` | Agente Claude Code assegnato |
 | `in-progress` | Agente al lavoro |
 | `review-ready` | PR pronta per test Davide |
-| `deployed-test` | Live su test (aggiunta da CI/bot) |
+| `deployed-test` | Live su test (aggiunta da CI) |
 | `needs-fix` | Reject, rework in corso |
 | `deployed-prod` | Live in produzione |
 
@@ -220,13 +214,13 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 |-------|--------------|
 | `create-issue` | Fase 1 — creazione issue leggera |
 | `issue-validate` | Fase 2 — validazione completa + research + piano |
-| `issue-implement` | Fase 3 — supervisione implementazione con checkpoint |
+| `issue-implement` | Fase 3 — implementazione con auto-gate |
 | `issue-pr-ready` | Fase 4 — checklist pre-PR, apertura PR, notifiche |
 | `issue-approve` | Fase 5a — merge + chiusura dopo /approva |
 | `issue-reject` | Fase 5b — rework dopo reject semplice |
 | `issue-research-rework` | Fase 5b — research approfondita per reject complessi |
 | `security-audit` | Pre-push — gate di sicurezza obbligatorio |
-| `8020-commit-workflow` | Convenzioni commit per l'agente |
+| `8020-commit-workflow` | Convenzioni commit |
 | `create-prd` | Creazione PRD da brief |
 | `prd-to-issues` | Breakdown PRD in issue |
 | `preparazione-repo` | Setup iniziale repo per workflow 8020 |
@@ -249,7 +243,7 @@ Usa sempre gli script in `scripts/` invece di comandi inline:
 ## 📝 Convenzioni
 
 - **Branch:** `feature/issue-N-slug`, `fix/issue-N-slug`
-- **Commit:** Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`) — dettagli in `COMMIT_CONVENTIONS.md`
+- **Commit:** Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`)
 - **Niente commit su main/master**
 - **PROJECT.md** aggiornato prima di ogni PR
 - **Weekly tracking:** dopo ogni merge, riga in `memory/weekly/current.md`

--- a/docs/CHECKPOINT_FORMAT.md
+++ b/docs/CHECKPOINT_FORMAT.md
@@ -22,7 +22,7 @@ Each checkpoint contains both a **human-readable** section and a **machine-reada
 **Prossimo step pianificato:**
 <description of next planned step>
 
-**Aspetto conferma di Claudio prima di procedere.**
+**Auto-gate: verifico autonomamente prima di procedere. In caso di blocco notifico Davide.**
 
 <!-- CHECKPOINT_DATA
 {"checkpoint":N,"status":"completed|in-progress|blocked","items_completed":2,"next_step":"description"}
@@ -41,7 +41,7 @@ Each checkpoint contains both a **human-readable** section and a **machine-reada
 | Cosa è stato fatto | Yes | Bullet list of completed items |
 | Risultati test | Yes | Test output, dry-run results, or "N/A" |
 | Prossimo step pianificato | Yes | What comes next |
-| Conferma line | Yes | Standard line requesting confirmation |
+| Auto-gate line | Yes | Standard line documenting auto-gate result |
 
 ### Machine-Readable Block (`CHECKPOINT_DATA`)
 
@@ -74,5 +74,5 @@ Use `scripts/parse-checkpoint.sh` to extract checkpoint data from issue comments
 1. Checkpoint numbers are sequential per issue (1, 2, 3, ...)
 2. Each checkpoint MUST contain the `<!-- CHECKPOINT_DATA ... -->` block
 3. The JSON block MUST be valid JSON on a single line
-4. Agents MUST wait for confirmation before proceeding past a checkpoint
+4. Agents proceed autonomously if gate passes; stop and notify Davide if blocked
 5. Only one checkpoint per comment

--- a/skills/8020-commit-workflow/SKILL.md
+++ b/skills/8020-commit-workflow/SKILL.md
@@ -2,20 +2,19 @@
 name: 8020-commit-workflow
 description: >
   This skill should be used whenever a git commit or git push is requested in any 80/20 Solutions project.
-  It enforces Claudio's (Senior Developer) duties from the 80/20 Solutions workflow: conventional commits,
-  semantic versioning, PROJECT.md validation, commit skin verification, branch strategy compliance,
-  and post-push coordination with Ciccio. Trigger on any mention of "commit", "push", "git commit",
+  It enforces the agent's duties from the 80/20 Solutions workflow: conventional commits,
+  semantic versioning, PROJECT.md validation, branch strategy compliance.
+  Trigger on any mention of "commit", "push", "git commit",
   "git push", or similar version control actions within the team's projects.
 ---
 
-# 8020 Solutions - Commit & Push Workflow (Claudio's Duties)
+# 8020 Solutions - Commit & Push Workflow
 
 ## Role Context
 
-In the 80/20 Solutions team, this agent acts as **Claudio** (Senior Developer). The workflow involves:
-- **David** = Product Owner (gives requirements, does final validation)
-- **Claudio** (this agent) = Senior Developer (develops, commits, notifies)
-- **Ciccio** = Orchestrator on VPS (handles deploy, merge, infrastructure)
+In the 80/20 Solutions team:
+- **David** = Product Owner (gives requirements, approves/rejects)
+- **Agent** (Claude Code) = handles everything else: implementation, commits, PR, merge
 
 Read `references/workflow-rules.md` for full workflow documentation.
 
@@ -93,7 +92,7 @@ After `git push`:
 
 1. CI deploys automatically to `test-*.8020solutions.org`
 2. Bot Telegram notifies Davide with test link + AC
-3. Claudio opens PR via skill `issue-pr-ready`
+3. Agent opens PR via skill `issue-pr-ready`
 4. Davide tests → `/approva` or `/reject`
 
 > IMPORTANT: Never push to master directly. Never merge without Davide's approval.

--- a/skills/8020-commit-workflow/references/workflow-rules.md
+++ b/skills/8020-commit-workflow/references/workflow-rules.md
@@ -1,3 +1,6 @@
+> ⚠️ **DEPRECATO** — Questo file è storico. Fonte di verità aggiornata: `WORKFLOW.md`
+> Ruoli attivi: solo **Davide** (Product Owner) e **Agente** (Claude Code). Claudio e Ciccio non sono più ruoli attivi.
+
 # 80/20 Solutions - Workflow Rules Complete Reference
 
 ## Team Roles

--- a/skills/8020-workflow/SKILL.md
+++ b/skills/8020-workflow/SKILL.md
@@ -57,3 +57,12 @@ Leggi `WORKFLOW.md` per il quadro generale. Leggi la skill specifica solo per la
 ```
 
 Nessuna eccezione. Anche se la fix sembra banale, Davide decide.
+
+---
+
+## 👥 Modello ruoli attuale
+
+- **Davide** — Product Owner: comanda, testa, approva/reject
+- **Agente** (Claude Code) — fa tutto il resto in autonomia
+
+Claudio e Ciccio non sono più ruoli attivi. L'agente gestisce issue, kanban, implementazione, PR e merge.

--- a/skills/8020-workflow/references/APPROVE_DEPLOY.md
+++ b/skills/8020-workflow/references/APPROVE_DEPLOY.md
@@ -27,4 +27,4 @@ gh issue close <N> --repo ecologicaleaving/<REPO>
 
 4. **Notifica Davide** con conferma
 
-5. **Se servono azioni infra** (env vars, DB, config) → prepara messaggio per Ciccio, proponi a Davide
+5. **Se servono azioni infra** (env vars, DB, config) → elenca le azioni da eseguire e comunicale a Davide

--- a/skills/8020-workflow/references/BRANCH_STRATEGY.md
+++ b/skills/8020-workflow/references/BRANCH_STRATEGY.md
@@ -1,3 +1,5 @@
+> ⚠️ **DEPRECATO** — Questo file è storico. Fonte di verità aggiornata: `WORKFLOW.md`
+
 # BRANCH_STRATEGY.md - Git Workflow Strategy
 
 **Strategia di branching standardizzata per 80/20 Solutions**

--- a/skills/8020-workflow/references/KANBAN.md
+++ b/skills/8020-workflow/references/KANBAN.md
@@ -6,12 +6,12 @@
 
 | Colonna | Chi sposta | Quando |
 |---------|-----------|--------|
-| **Backlog** | Claudio | Issue creata |
-| **Todo** | Claudio | Validata, piano pronto |
-| **InProgress** | Claudio | Dopo /vai, agente al lavoro |
-| **Test** | Claudio | PR aperta, CI deploya in test |
-| **Review** | Claudio | Dopo /reject, rework |
-| **Done** | Claudio | Dopo /approva, PR mergiata |
+| **Backlog** | Agente | Issue creata |
+| **Todo** | Agente | Validata, piano pronto |
+| **InProgress** | Agente | Dopo /vai, implementazione avviata |
+| **Test** | Agente | PR aperta, CI deploya in test |
+| **Review** | Agente | Dopo /reject, rework |
+| **Done** | Agente | Dopo /approva, PR mergiata |
 
 ## Spostare una card
 
@@ -20,6 +20,6 @@
 ```
 
 ## Regole
-- La colonna **Deploy** non è più usata — Claudio mergia direttamente dopo /approva
+- La colonna **Deploy** non è più usata — l'agente mergia direttamente dopo /approva
 - Lo stato è la colonna Kanban
 - Label agente NON si rimuove durante la lavorazione

--- a/skills/8020-workflow/references/WORKFLOW_CICCIO.md
+++ b/skills/8020-workflow/references/WORKFLOW_CICCIO.md
@@ -1,21 +1,7 @@
-# WORKFLOW_CICCIO.md — Ruolo Ciccio (VPS)
+# WORKFLOW_CICCIO.md — Infra VPS (senza Ciccio)
 
-> Riferimento rapido. Il flusso completo è in `WORKFLOW.md`.
-
-## Ruolo
-
-Ciccio gestisce infrastruttura e azioni VPS su richiesta.
-
-**Responsabilità:**
-- Gestione VPS, database, domini, SSL
-- Azioni infra su richiesta di Claudio (env vars, migrazioni DB, config)
-- Sviluppo web se necessario
-
-**NON fa:**
-- Merge PR (lo fa Claudio dopo /approva)
-- Creazione/lavorazione issue (Claudio)
-- Lancio agenti (Claudio)
-- Modifiche alla repo workflow (solo Claudio)
+> Riferimento rapido per azioni infra che prima gestiva Ciccio.
+> Ora vengono elencate dall'agente e eseguite manualmente da Davide.
 
 ## VPS
 
@@ -23,3 +9,38 @@ Ciccio gestisce infrastruttura e azioni VPS su richiesta.
 - **Domini**: *.8020solutions.org
 - **SSL**: Let's Encrypt auto-renewal
 - **Docker**: v29.2.1 + Compose v5.0.2
+
+## Azioni infra comuni
+
+Quando l'agente segnala azioni infra necessarie (Step 5 di `issue-approve`), Davide le esegue direttamente sul VPS:
+
+### Env vars
+
+```bash
+ssh root@46.225.60.101
+cd /opt/<repo>
+nano .env  # aggiungi la variabile
+docker compose restart <service>
+```
+
+### Migrazioni DB
+
+```bash
+ssh root@46.225.60.101
+cd /opt/<repo>
+docker compose exec app <migration-command>
+```
+
+### Riavvio servizio
+
+```bash
+ssh root@46.225.60.101
+cd /opt/<repo>
+docker compose pull && docker compose up -d
+```
+
+## Note
+
+- L'agente non ha accesso SSH al VPS — elenca le azioni, Davide le esegue
+- Per deploy: la CI gestisce tutto automaticamente (push → build → deploy)
+- Azioni infra manuali sono l'eccezione, non la regola

--- a/skills/8020-workflow/references/WORKFLOW_CLAUDE_CODE.md
+++ b/skills/8020-workflow/references/WORKFLOW_CLAUDE_CODE.md
@@ -1,3 +1,6 @@
+> ⚠️ **DEPRECATO** — Questo file è storico. Fonte di verità aggiornata: `WORKFLOW.md`
+> Ruoli attivi: solo **Davide** (Product Owner) e **Agente** (Claude Code). Non esiste più intermediario Claudio/Ciccio.
+
 # WORKFLOW_CLAUDE_CODE.md - Senior Developer  
 
 **Ruolo**: Senior Developer, Build Engineer, Implementation Lead  

--- a/skills/8020-workflow/references/WORKFLOW_DAVID.md
+++ b/skills/8020-workflow/references/WORKFLOW_DAVID.md
@@ -1,3 +1,6 @@
+> ⚠️ **DEPRECATO** — Questo file è storico. Fonte di verità aggiornata: `WORKFLOW.md`
+> Ruoli attivi: solo **Davide** (Product Owner) e **Agente** (Claude Code). Ciccio non è più attivo.
+
 # WORKFLOW_DAVID.md - Product Owner & Strategic Lead
 
 **Ruolo**: Product Owner, Strategic Decision Maker, Business Lead  

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -1,8 +1,8 @@
 # Skill: create-issue
 
 **Trigger:** `/create-issue` o Davide descrive un bug/feature in modo grezzo
-**Agente:** Claudio
-**Versione:** 3.0.0
+**Agente:** Claude Code
+**Versione:** 4.0.0
 
 ---
 

--- a/skills/create-prd/SKILL.md
+++ b/skills/create-prd/SKILL.md
@@ -1,7 +1,7 @@
 # Skill: create-prd
 
 **Trigger:** `/create-prd` o Davide descrive un'idea per un progetto/feature grande  
-**Agente:** Claudio  
+**Agente:** Claude Code  
 **Versione:** 1.0.0
 
 ---

--- a/skills/issue-approve/SKILL.md
+++ b/skills/issue-approve/SKILL.md
@@ -1,8 +1,8 @@
 # Skill: issue-approve
 
-**Trigger:** Davide scrive `/approva`  
-**Agente:** Claudio  
-**Versione:** 2.0.0
+**Trigger:** Davide scrive `/approva`
+**Agente:** Claude Code
+**Versione:** 3.0.0
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 5a
 
@@ -10,7 +10,7 @@
 
 ## Obiettivo
 
-Mergiare la PR, chiudere la issue, notificare. Ciccio coinvolto solo se servono azioni infra.
+Mergiare la PR, chiudere la issue, notificare Davide. Gestire eventuali azioni infra necessarie.
 
 ---
 
@@ -48,9 +48,17 @@ gh issue close <N> --repo ecologicaleaving/<repo>
 
 ### Step 5 — Azioni infra (solo se necessario)
 
-Se servono env vars, migrazioni DB, config VPS → prepara messaggio per Ciccio e proponilo a Davide prima di inviare.
+Se servono env vars, migrazioni DB, config VPS → elenca le azioni da eseguire e comunicale a Davide:
 
-Se non servono azioni infra → nessun coinvolgimento di Ciccio.
+```
+⚙️ Azioni infra richieste per questa issue:
+- [ ] <azione 1> (es. aggiungere env var XYZ al VPS)
+- [ ] <azione 2> (es. eseguire migrazione DB)
+
+Queste vanno eseguite manualmente sul VPS.
+```
+
+Se non servono azioni infra → skip questo step.
 
 ### Step 6 — Weekly tracking
 

--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -1,110 +1,58 @@
 # Skill: issue-implement
 
-**Trigger:** `/vai` di Davide — piano approvato, agente prosegue con implementazione
-**Agente:** Claudio (supervisione) + stesso Sonnet della Fase 2 (esecuzione)
-**Versione:** 4.0.0
+**Trigger:** `/vai` di Davide — piano approvato, implementazione parte
+**Agente:** Claude Code
+**Versione:** 5.0.0
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 3
-> L'agente è lo stesso della Fase 2 (research + piano) — mantiene il contesto.
 
 ---
 
 ## Obiettivo
 
-Sbloccare l'agente per l'implementazione e supervisionare fino al gate finale.
-L'agente lavora in autonomia — Claudio interviene solo al gate finale o su anomalie.
+Implementare la issue seguendo il piano, auto-validare al gate finale, pushare e aprire PR.
+L'agente lavora in autonomia — si blocca solo su anomalie o gate fallito.
 
 ---
 
 ## Procedura
 
-### Step 1 — Sblocca l'agente
+### Step 1 — Sposta card → InProgress
 
-Dopo `/vai` di Davide, Claudio:
-
-1. Sposta card → InProgress: `./scripts/kanban-move.sh <N> <repo> InProgress`
-2. Invia messaggio all'agente (stessa sessione della Fase 2):
-
+```bash
+./scripts/kanban-move.sh <N> <repo> InProgress
 ```
-Piano approvato da Davide. Procedi con l'implementazione.
 
-Regole:
-- Segui il piano che hai prodotto
-- Commit atomici con Conventional Commits (feat:, fix:, chore:)
+Notifica Davide:
+```
+✅ [Issue #N] Implementazione avviata
+```
+
+---
+
+### Step 2 — Implementa
+
+Segui il piano prodotto in `issue-validate`:
+- Commit atomici con Conventional Commits (`feat:`, `fix:`, `chore:`)
 - Esegui test dopo ogni modifica significativa
-- Se trovi un problema che non sai risolvere → FERMATI e segnala
-- Quando hai finito: esegui security audit (scripts/security-audit.sh), poi posta il gate finale
-```
+- Se trovi un problema non risolvibile → FERMATI e notifica Davide
 
-3. Notifica Davide:
-```
-✅ [Issue #N] Agente al lavoro
-📌 Implementazione avviata
-```
-
-### Step 2 — Monitora (non interrompere)
-
-L'agente lavora. Claudio monitora via agent-monitor ma **non interviene** a meno di anomalie.
-
-**Criteri anomalia (auto-blocco):**
+**Criteri auto-blocco:**
 - Test falliti per più di 3 tentativi sullo stesso errore
 - File modificati fuori scope del piano
 - Più di 5 iterazioni senza convergenza
 - Errore grave o comportamento inatteso
 
-Se anomalia → Claudio notifica Davide:
+Se anomalia:
 ```
 ⚠️ [Issue #N] Anomalia — <descrizione>
-📌 <cosa ha fatto l'agente>
+📌 <cosa è successo>
 ❓ Come procedo?
 ```
 
-### Step 3 — Gate finale
-
-L'agente posta un commento sulla issue con questo formato:
-
-```
-## ✅ Gate Finale — Pronto per push
-
-**Cosa è stato fatto:**
-<descrizione>
-
-**AC verificati:**
-- ✅ AC1 — <come è stato verificato>
-- ✅ AC2 — ...
-
-**Test:**
-- Lint: ✅/❌
-- Typecheck: ✅/❌
-- Unit test: ✅/❌
-- Build: ✅/❌
-
-**Security audit:**
-<risultato scripts/security-audit.sh>
-
-**File modificati:**
-<lista>
-
-**Aspetto conferma di Claudio prima di pushare.**
-```
-
-### Step 4 — Claudio valida il gate
-
-**Checklist Claudio:**
-- [ ] Tutti gli AC soddisfatti
-- [ ] Test e build passati
-- [ ] Security audit passato
-- [ ] PROJECT.md aggiornato
-- [ ] Nessun file anomalo (.env, debug, config sensibili)
-- [ ] Migrazioni DB incluse (se applicabile)
-
-**Se ok:** `✅ procedi` → agente pusha → Claudio segue skill `issue-pr-ready`
-
-**Se problemi:** `🔴 bloccato — <motivo e istruzioni>` → agente fixa → ripete gate
-
 ---
 
-## Build obbligatoria (l'agente la esegue prima del gate)
+### Step 3 — Build obbligatoria
 
 **Flutter (se `pubspec.yaml` presente):**
 ```bash
@@ -119,19 +67,47 @@ npm ci && npm run build && npm test
 
 ---
 
-## Convenzioni Agente
+### Step 4 — Security audit (obbligatorio)
 
-Vedi `WORKFLOW.md` per branch e convenzioni. Vedi `COMMIT_CONVENTIONS.md` per commit.
+```bash
+./scripts/security-audit.sh
+```
+
+Vedi skill `security-audit` per i check manuali aggiuntivi.
 
 ---
 
-## 🔍 Agent Monitor (obbligatorio)
+### Step 5 — Auto-gate finale
 
-Vedi [agent-monitor.md](../references/agent-monitor.md) per istruzioni.
+Verifica autonomamente prima di pushare:
+
+- [ ] Tutti gli AC soddisfatti
+- [ ] Test e build passati
+- [ ] Security audit passato
+- [ ] PROJECT.md aggiornato
+- [ ] Nessun file anomalo (.env, debug, config sensibili)
+- [ ] Migrazioni DB incluse (se applicabile)
+
+**Se tutto ok** → procedi con il push (Step 6).
+
+**Se problemi** → fixa e ripeti il gate. Dopo 3 tentativi falliti → blocca e notifica Davide.
+
+---
+
+### Step 6 — Push e PR
+
+Gate superato → procedi con `issue-pr-ready`.
+
+---
+
+## 🔍 Agent Monitor
+
+Vedi `skills/references/agent-monitor.md` per istruzioni.
 
 ---
 
 ## Changelog
 
+- **v5.0.0** (2026-04-13): Rimosso ruolo Claudio — auto-gate, agente procede autonomamente al push
 - **v4.0.0** (2026-04-03): Agente unico (stesso della Fase 2), gate finale unico, rimossi checkpoint intermedi
 - **v3.0.0** (2026-04-03): Riduzione a 3 checkpoint, rimossa duplicazione

--- a/skills/issue-pr-ready/SKILL.md
+++ b/skills/issue-pr-ready/SKILL.md
@@ -15,22 +15,18 @@ and the branch is ready for pull request and review.
 
 ## Prerequisites
 
-- All acceptance criteria verified (code complete)
-- Branch is up to date with target branch
-- `config.json` is available in the workflow repo root
-- `gh` CLI authenticated and available
-- `scripts/generate-pr-body.sh` available in the workflow repo
+- Auto-gate finale superato (issue-implement Step 5)
+- Branch aggiornato rispetto al branch target
+- `config.json` disponibile nella root del workflow repo
+- `gh` CLI autenticato e disponibile
+- `scripts/generate-pr-body.sh` disponibile nel workflow repo
 
 ## Procedure
 
-### Step 1 — Verify CP3 passed
-
-All checks were done at CP3 (`issue-implement`). Verify the checkpoint was approved before proceeding.
-
-### Step 2 — Push Branch and Open PR
+### Step 1 — Push Branch e Apertura PR
 
 ```bash
-# Read config values
+# Leggi valori da config
 REPO=$(jq -r '.github.repos["<project>"]' config.json)
 DEFAULT_BRANCH=$(jq -r '.workflow.defaultBranch' config.json)
 BRANCH=$(git branch --show-current)
@@ -38,10 +34,10 @@ BRANCH=$(git branch --show-current)
 # Push branch
 git push origin "$BRANCH"
 
-# Generate PR body using the template script
+# Genera body PR dal template
 PR_BODY=$(./scripts/generate-pr-body.sh "$ISSUE_NUMBER")
 
-# Open PR
+# Apri PR
 gh pr create \
   --repo "$REPO" \
   --base "$DEFAULT_BRANCH" \
@@ -50,51 +46,41 @@ gh pr create \
   --body "$PR_BODY"
 ```
 
-### Step 3 — Move Kanban Card → Test
+### Step 2 — Sposta Card Kanban → Test
 
 ```bash
 ./scripts/kanban-move.sh "$ISSUE_NUMBER" "$REPO" Test
 ```
 
-### Step 4 — Add Label `review-ready`
+### Step 3 — Aggiungi Label `review-ready`
 
 ```bash
 gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "review-ready"
 ```
 
-### Step 5 — Notify Davide
-
-Send a structured notification to Davide with test instructions:
+### Step 4 — Notifica Davide
 
 ```
-📋 Issue #<N> — <Title> pronta per test
+✅ [Issue #N] PR pronta → <link PR>
+📌 <summary>
 
-**Branch:** <branch-name>
-**PR:** <pr-url>
-**Repo:** <repo>
+🧪 Come testare:
+1. <istruzione 1>
+2. <istruzione 2>
 
-**Cosa testare:**
-1. <test instruction 1>
-2. <test instruction 2>
+💡 Cosa aspettarsi:
+<risultato atteso>
 
-**Come testare:**
-- `git checkout <branch>`
-- <run instructions>
+**AC verificati:**
+- ✅ AC1 — <descrizione>
+- ✅ AC2 — <descrizione>
 
-**AC verificati dall'agente:**
-- ✅ AC1 — <description>
-- ✅ AC2 — <description>
-...
-
-Quando hai testato, usa:
-- `/approva` se tutto ok
-- `/reject <motivo>` se serve rework
+→ /approva se ok | /reject <motivo> se serve rework
 ```
 
 ## Note
 
 - CI deploya automaticamente su test dopo il push del branch
-- Bot Telegram notifica Davide con link + AC
 - Dopo `/approva` di Davide → skill `issue-approve`
 - Dopo `/reject` di Davide → skill `issue-reject`
 - Valori config (project ID, field ID, column ID): vedi `config.json`

--- a/skills/issue-reject/SKILL.md
+++ b/skills/issue-reject/SKILL.md
@@ -1,8 +1,8 @@
 # Skill: issue-reject
 
-**Trigger:** Davide scrive `/reject <feedback>`  
-**Agente:** Claudio  
-**Versione:** 2.1.0
+**Trigger:** Davide scrive `/reject <feedback>`
+**Agente:** Claude Code
+**Versione:** 3.0.0
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 5b
 
@@ -10,7 +10,7 @@
 
 ## Obiettivo
 
-Gestire il rework dopo un reject: aggiornare la issue con feedback e risultati test, rilanciare l'agente con il contesto necessario.
+Gestire il rework dopo un reject: registrare feedback e risultati test sulla issue, ripartire con l'implementazione.
 
 ---
 
@@ -18,7 +18,7 @@ Gestire il rework dopo un reject: aggiornare la issue con feedback e risultati t
 
 ### Step 1 — Raccolta feedback
 
-Se Davide non ha specificato risultati test nel reject, Claudio chiede:
+Se Davide non ha specificato risultati test nel reject, chiedi:
 ```
 Hai risultati dei test da allegare al reject? (log, screenshot, descrizione errore)
 ```
@@ -42,7 +42,7 @@ gh issue comment <N> --repo ecologicaleaving/<repo> --body "
 - <action item 2>
 
 ---
-*Reject ricevuto il $(date +%Y-%m-%d %H:%M) — Agente in rework*
+*Reject ricevuto il $(date +%Y-%m-%d %H:%M) — Rework in corso*
 "
 ```
 
@@ -60,21 +60,12 @@ gh issue edit <N> --repo ecologicaleaving/<repo> \
 ./scripts/kanban-move.sh <N> <repo> Review
 ```
 
-### Step 5 — Rilancia agente con contesto
+### Step 5 — Avvia rework
 
-Istruzioni da passare all'agente:
-
-```
-La issue #N è stata rifiutata. 
-Leggi l'ultimo commento di rework sulla issue per il feedback completo.
-
-Feedback: <feedback>
-Risultati test: <risultati>
-
-Parti dalla PR esistente (branch: feature/issue-N-slug).
-Analizza il problema, proponi il fix, implementa.
-Segui i checkpoint obbligatori come da issue.
-```
+Riprendi dal branch esistente (`feature/issue-N-slug`).
+Leggi l'ultimo commento sulla issue per il feedback completo.
+Analizza il problema, implementa il fix.
+Segui il flusso `issue-implement` (auto-gate, poi `issue-pr-ready`).
 
 ### Step 6 — Sposta card → InProgress
 
@@ -87,13 +78,13 @@ Segui i checkpoint obbligatori come da issue.
 ```
 🔄 [Issue #N] Rework avviato
 📌 Feedback registrato sulla issue
-🤖 Agente in lavorazione con il contesto del reject
-📬 Ti aggiornerò ai checkpoint
+🤖 In lavorazione — ti aggiorno al gate
 ```
 
 ---
 
 ## Nota
 
-Il loop reject → rework → test review continua fino a `/approva` di Davide.  
+Il loop reject → rework → test continua fino a `/approva` di Davide.
 Ogni reject viene numerato progressivamente nella issue (Rework 1, Rework 2, ecc.)
+Dopo 2+ reject usa la skill `issue-research-rework` per un'analisi più approfondita.

--- a/skills/issue-research-rework/SKILL.md
+++ b/skills/issue-research-rework/SKILL.md
@@ -1,7 +1,7 @@
 # Skill: issue-research-rework
 
 **Trigger:** Rework complicato dopo reject — serve analisi approfondita prima di implementare  
-**Agente:** Claudio o Ciccio (chi supervisiona)  
+**Agente:** Claude Code  
 **Versione:** 1.1.0
 
 ---

--- a/skills/issue-validate/SKILL.md
+++ b/skills/issue-validate/SKILL.md
@@ -1,8 +1,8 @@
 # Skill: issue-validate
 
 **Trigger:** `/issue-validate #N` o `/valida #N`
-**Agente:** Claudio (interattivo con Davide) + Sonnet (research + piano + implementazione)
-**Versione:** 3.0.0
+**Agente:** Claude Code
+**Versione:** 4.0.0
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 2
 
@@ -49,7 +49,7 @@ Se una risposta è già chiara dal contesto, skippa la domanda.
 
 ### Step 1b — Verifica versioni dipendenze (obbligatorio)
 
-Prima di aggiornare la issue, verifica le versioni dei tool e librerie coinvolti nell'implementazione:
+Prima di aggiornare la issue, verifica le versioni dei tool e librerie coinvolti:
 
 ```bash
 cd /tmp/<repo>
@@ -68,8 +68,6 @@ node --version 2>/dev/null
 flutter --version 2>/dev/null | head -3
 ```
 
-**Perché:** le dipendenze esistenti determinano quale approccio tecnico è compatibile (es. Next.js 15 vs 14 ha API diverse, googleapis richiede versione specifica di Node, ecc.).
-
 Riporta le versioni rilevanti nel body aggiornato della issue nella sezione "Note tecniche".
 
 ---
@@ -79,11 +77,10 @@ Riporta le versioni rilevanti nel body aggiornato della issue nella sezione "Not
 Dopo aver raccolto le risposte, prima di aggiornare la issue:
 
 1. Identifica le issue future che dipendono da questa (stessa epic, stessa area funzionale)
-2. Verifica se le decisioni prese nella validazione impattano quelle issue (es. cambio architettura, nuovi campi DB, nuova logica)
+2. Verifica se le decisioni prese nella validazione impattano quelle issue
 3. Se sì → proponi aggiornamento a Davide e aggiorna anche quelle issue
 
 ```bash
-# Controlla issue aperte della stessa epic
 gh issue list --repo ecologicaleaving/<repo> --state open \
   --label "<epic>" --json number,title,body | jq '.[]'
 ```
@@ -122,20 +119,14 @@ echo "=== Test ==="
 curl -s -o /dev/null -w "HTTP %{http_code}" "https://test-$REPO.8020solutions.org"
 ```
 
-Se qualcosa manca → blocca e notifica Davide + Ciccio.
+Se qualcosa manca → blocca e notifica Davide.
 
 ---
 
-### Step 4 — Lancia Sonnet (research + piano)
+### Step 4 — Research + piano
 
-Un solo agente fa esplorazione e piano. Questo agente verrà poi riutilizzato per l'implementazione dopo `/vai`.
+Esplora il codebase in modo approfondito, poi produci un piano dettagliato:
 
-```
-Leggi la issue #N su ecologicaleaving/<repo>.
-Clona o aggiorna il repo localmente.
-Esplora il codebase in modo approfondito.
-
-Poi produci un piano dettagliato:
 1. Struttura progetto e file rilevanti
 2. Codice esistente collegato alla issue + versioni dipendenze
 3. File da toccare (con motivazione)
@@ -145,43 +136,37 @@ Poi produci un piano dettagliato:
 7. Stima complessità
 
 ⚠️ NON modificare alcun file in questa fase. Solo lettura, analisi e piano.
-```
-
-Modello: `anthropic/claude-sonnet-4-6`
-
-> ⚠️ **Importante:** Lancia con `mode: "session"` (non `"run"`) così l'agente resta vivo per l'implementazione dopo `/vai`.
 
 ---
 
-### Step 6 — Valuta il piano
+### Step 5 — Auto-validazione piano
 
 **✅ Piano ok se:**
 - Copre tutti gli AC definiti con Davide
 - File identificati sensati e in scope
 - Nessun approccio rischioso
 - Task checklist dettagliata e realistica
-- Coerente con le decisioni prese nella validazione (es. architettura DB, logica business)
+- Coerente con le decisioni prese nella validazione
 
 **⚠️ Anomalia se:**
 - Piano ignora degli AC
 - Vuole toccare file fuori scope
 - Approccio tecnico sbagliato o incongruente con il codebase esistente
-- Propone soluzioni già escluse durante la validazione
 
 Se anomalia → blocca e notifica Davide prima di procedere.
 
 ---
 
-### Step 7 — Posta piano come commento sulla issue
+### Step 6 — Posta piano come commento sulla issue
 
 ```bash
 gh issue comment <N> --repo ecologicaleaving/<repo> \
-  --body "## 📝 Piano (generato da Sonnet)\n\n<piano completo>"
+  --body "## 📝 Piano\n\n<piano completo>"
 ```
 
 ---
 
-### Step 8 — Sposta card → Todo
+### Step 7 — Sposta card → Todo
 
 ```bash
 ./scripts/kanban-move.sh <N> <repo> Todo
@@ -189,7 +174,7 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 
 ---
 
-### Step 9 — Notifica Davide e aspetta `/vai`
+### Step 8 — Notifica Davide e aspetta `/vai`
 
 ```
 ✅ [Issue #N] Piano pronto — <titolo>
@@ -197,14 +182,13 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 ⏭️ Scrivi /vai per avviare l'implementazione
 ```
 
-⚠️ **Claudio NON avvia mai l'implementazione senza `/vai` esplicito di Davide.**
+⚠️ **L'agente NON avvia mai l'implementazione senza `/vai` esplicito di Davide.**
 
 ---
 
 ## Changelog
 
+- **v4.0.0** (2026-04-13): Rimosso ruolo Claudio — agente unico gestisce tutto
 - **v3.0.0** (2026-04-03): Agente unico Sonnet per research+piano+implementazione, rimosso Haiku separato
-- **v2.0.0** (2026-04-03): Refactor — Opus→Sonnet per piano, rimossa duplicazione modelli (vedi WORKFLOW.md), verifica deploy condizionale, assorbita issue-start
-- **v1.2.0** (2026-03-31): Aggiunto Step 1b — verifica versioni dipendenze
-- **v1.1.0** (2026-03-31): Aggiunto Step 1b — verifica coerenza issue future collegate
+- **v2.0.0** (2026-04-03): Refactor — Opus→Sonnet per piano, rimossa duplicazione modelli
 - **v1.0.0** (2026-03-31): Prima versione

--- a/skills/pdf-to-md/SKILL.md
+++ b/skills/pdf-to-md/SKILL.md
@@ -9,7 +9,7 @@ description: >
 # Skill: pdf-to-md
 
 **Trigger:** Prima di leggere qualsiasi file `.pdf`
-**Agente:** Tutti (Claudio, Claude Code, subagent)
+**Agente:** Tutti (Claude Code, subagent)
 **Versione:** 2.0.0
 
 ---
@@ -97,8 +97,7 @@ Leggi il `.md` appena creato per il task originale. Non toccare più il PDF.
 ## Dove si applica
 
 Questa skill è **obbligatoria** per tutti gli agenti del team:
-- Claudio (supervisore)
-- Agenti implementazione (Claude Code / Sonnet)
-- Subagent research (Haiku)
+- Agente (Claude Code / Sonnet)
+- Subagent research
 
 Va referenziata nel `CLAUDE.md` di ogni progetto che contiene PDF.

--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -1,7 +1,7 @@
 # Skill: prd-to-issues
 
 **Trigger:** `/prd-to-issues` o Davide chiede di creare le issue da un PRD  
-**Agente:** Claudio  
+**Agente:** Claude Code  
 **Versione:** 1.0.0  
 **Dipendenza:** PRD già creato (skill `create-prd`)
 
@@ -232,9 +232,9 @@ Dimmi quale issue vuoi avviare per prima!
 
 ### Issue infra/VPS
 Se dal PRD emergono task infrastrutturali (setup DB, DNS, certificati SSL, nginx config):
-- Creale come issue separate con label `agent:ciccio`
+- Creale come issue separate con label `infra`
 - Mettile in Fase 1 (setup) con priorità alta
-- Nota: queste le lavora Ciccio, non Claude Code
+- Nota: queste richiedono azioni manuali sul VPS — notifica Davide con la lista comandi
 
 ### Progetto nuovo senza repo
 Se la repo non esiste ancora:

--- a/skills/preparazione-repo/SKILL.md
+++ b/skills/preparazione-repo/SKILL.md
@@ -203,7 +203,7 @@ PROJECT.md
 Notifiche Deploy Telegram
   ✅ Secrets presenti (TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID)
   ✅ Job notify-deploy presente nel workflow CI
-  / ❌ Assenti → segnala a Ciccio (vedi DEPLOY-NOTIFY-SETUP.md)
+  / ❌ Assenti → aggiungi i secrets su GitHub e verifica DEPLOY-NOTIFY-SETUP.md
 
 Curl Test
   ✅ tests/curl-tests.sh presente

--- a/skills/preparazione-repo/assets/CLAUDE.md.template
+++ b/skills/preparazione-repo/assets/CLAUDE.md.template
@@ -39,15 +39,14 @@ Non procedere con nessuna attività prima di aver completato questi 3 step.
 ## Team
 
 - **Davide (Boss):** Decisore finale, approva/rifiuta il lavoro
-- **Claude Code (io):** Senior Dev — sviluppo, debug, test, code review
-- **Ciccio (VPS):** Orchestratore — merge, deploy, infrastruttura
+- **Agente (Claude Code):** Gestisce tutto il ciclo — sviluppo, kanban, PR, merge
 
 ## Regole Fondamentali
 
 - **MAI pushare su main/master** — sempre branch `feature/issue-{N}-{slug}`
 - **MAI inventare** credenziali, configurazioni o soluzioni incerte — chiedi a Davide
-- **Segui le skill** del workflow (issue-start, issue-done, 8020-commit-workflow)
-- Se serve infrastruttura VPS/DB → chiedi a Ciccio tramite Davide
+- **Segui le skill** del workflow (issue-validate, issue-implement, issue-pr-ready, issue-approve)
+- Se servono azioni infra VPS/DB → elenca i comandi e comunicali a Davide
 
 ## Curl Test
 

--- a/skills/preparazione-repo/references/labels.md
+++ b/skills/preparazione-repo/references/labels.md
@@ -6,9 +6,8 @@ Lista completa delle label che ogni repo del workflow deve avere.
 
 | Nome | Colore | Descrizione |
 |------|--------|-------------|
-| `claude-code` | `#0075ca` | Assegnata a Claude Code (PC locale) |
-| `ciccio` | `#e4e669` | Assegnata a Ciccio (VPS) |
-| `codex` | `#d876e3` | Assegnata a Codex |
+| `claude-code` | `#0075ca` | Assegnata a Claude Code |
+| `infra` | `#e4e669` | Task infrastrutturale (VPS, DB, domini) |
 
 ## Label Stato Workflow
 

--- a/skills/repo-maintenance/SKILL.md
+++ b/skills/repo-maintenance/SKILL.md
@@ -1,25 +1,25 @@
 # Skill: repo-maintenance
 
-**Trigger:** Su richiesta di Davide, dopo ogni issue completata, o quando Claudio rileva che i file sono out-of-sync  
-**Agente:** Claudio  
-**Versione:** 2.0.0
+**Trigger:** Su richiesta di Davide, dopo ogni issue completata, o quando l'agente rileva che i file sono out-of-sync
+**Agente:** Claude Code
+**Versione:** 3.0.0
 
 ---
 
 ## Obiettivo
 
-Mantenere aggiornati i file di configurazione e workflow di ogni repo del team. Claudio lo fa in automatico e riporta a Davide; escala solo se trova anomalie o ha bisogno di input.
+Mantenere aggiornati i file di configurazione e workflow di ogni repo del team. L'agente lo fa in automatico e riporta a Davide; escala solo se trova anomalie o ha bisogno di input.
 
 ---
 
-## File sotto responsabilità di Claudio
+## File sotto responsabilità dell'agente
 
 ### Sempre aggiornati (in qualsiasi momento)
 
 | File | Contenuto | Trigger aggiornamento |
 |------|-----------|----------------------|
 | `CLAUDE.md` | Hook avvio agente, regole vincolanti | Cambio workflow, nuove regole, su richiesta Davide |
-| `AGENTS.md` | Stessa cosa in inglese (per Codex) | Cambio workflow, nuove regole, su richiesta Davide |
+| `AGENTS.md` | Stessa cosa in inglese | Cambio workflow, nuove regole, su richiesta Davide |
 | `PROJECT.md` | Stack, URL, stato deploy, backlog | Dopo ogni issue completata, cambio infra, cambio stack |
 | `.workflow/` | Submodule regole operative | Sync automatico all'avvio agente |
 
@@ -27,9 +27,9 @@ Mantenere aggiornati i file di configurazione e workflow di ogni repo del team. 
 
 | File | Contenuto | Chi lo aggiorna |
 |------|-----------|----------------|
-| `README.md` | Documentazione pubblica progetto | Agente (verifica Claudio in checklist PR) |
-| `CHANGELOG.md` | Storia delle versioni | Agente (verifica Claudio in checklist PR) |
-| `docs/` | Documentazione tecnica | Agente (verifica Claudio in checklist PR) |
+| `README.md` | Documentazione pubblica progetto | Agente (checklist PR) |
+| `CHANGELOG.md` | Storia delle versioni | Agente (checklist PR) |
+| `docs/` | Documentazione tecnica | Agente (checklist PR) |
 
 ---
 
@@ -38,7 +38,6 @@ Mantenere aggiornati i file di configurazione e workflow di ogni repo del team. 
 ### Step 1 — Verifica stato file
 
 ```bash
-# Controlla che i file esistano e siano aggiornati
 gh api repos/ecologicaleaving/<repo>/contents/CLAUDE.md --jq '.sha' 2>/dev/null
 gh api repos/ecologicaleaving/<repo>/contents/AGENTS.md --jq '.sha' 2>/dev/null
 gh api repos/ecologicaleaving/<repo>/contents/PROJECT.md --jq '.sha' 2>/dev/null
@@ -55,14 +54,11 @@ Se la versione del template è più recente o le regole sono cambiate → aggior
 ### Step 3 — Aggiorna file su repo
 
 ```bash
-# Leggi SHA corrente (necessario per update)
 SHA=$(gh api repos/ecologicaleaving/<repo>/contents/CLAUDE.md --jq '.sha')
-
-# Aggiorna file
 CONTENT=$(base64 -w 0 < templates/CLAUDE.md)
 gh api repos/ecologicaleaving/<repo>/contents/CLAUDE.md \
   --method PUT \
-  --field message="chore: aggiorna CLAUDE.md a workflow v2.0" \
+  --field message="chore: aggiorna CLAUDE.md a workflow v4.0" \
   --field content="$CONTENT" \
   --field sha="$SHA"
 ```
@@ -83,7 +79,6 @@ Aggiorna solo i campi che sono cambiati:
 ### Step 5 — Sync submodule .workflow
 
 ```bash
-# Nel repo del progetto
 git submodule update --remote .workflow
 git add .workflow
 git commit -m "chore: sync workflow submodule"
@@ -94,22 +89,22 @@ git push
 
 ## Logica Automatica vs Escalation
 
-### Claudio fa in automatico e riporta:
+### L'agente fa in automatico e riporta:
 
 ```
 ✅ [Repo: <repo>] File aggiornati
-📄 CLAUDE.md → v2.0 (era v1.x)
-📄 AGENTS.md → v2.0 (era v1.x)
+📄 CLAUDE.md → v4.0 (era v1.x)
+📄 AGENTS.md → v4.0 (era v1.x)
 📄 PROJECT.md → versione bumped, issue #N segnata done
 🔗 .workflow → synced
 ```
 
-### Claudio escala a Davide se:
+### L'agente escala a Davide se:
 
 - `PROJECT.md` manca e non sa come crearlo (stack sconosciuto)
 - C'è un conflitto tra il contenuto attuale e il template (personalizzazioni locali)
 - Il submodule `.workflow` non esiste nel repo (repo non ancora integrata)
-- Claudio non ha i permessi per fare push (repo protetta)
+- L'agente non ha i permessi per fare push (repo protetta)
 
 **Formato escalation:**
 ```
@@ -121,8 +116,6 @@ git push
 ---
 
 ## Trigger Automatici
-
-Claudio esegue `repo-maintenance` automaticamente in questi casi:
 
 | Evento | Azione |
 |--------|--------|

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -107,7 +107,7 @@ Se lo script trova problemi critici (exit code 1):
 ### Problemi dai check manuali
 Se i check manuali trovano problemi:
 - L'agente **segnala nel commento** sulla issue
-- **Aspetta conferma di Claudio** prima di procedere
+- **Notifica Davide** sulla issue e aspetta istruzioni
 
 ### Verdict
 - **✅ PASS** — solo se script passa E check manuali ok/N/A → l'agente può procedere al push
@@ -124,5 +124,5 @@ Se i check manuali trovano problemi:
 4. Valuta check manuali leggendo il codice
 5. Posta commento sulla issue con il report
 6. Se PASS → procedi al push
-7. Se BLOCKED → aspetta conferma di Claudio
+7. Se BLOCKED → fixa i problemi critici, notifica Davide per quelli non risolvibili
 ```

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -12,7 +12,7 @@ git submodule update --init --remote .workflow
 ### 2. Read the operational rules
 `.workflow/skills/issue-implement/SKILL.md`
 
-Contains the mandatory checkpoint protocol, commit conventions, branch strategy.
+Contains the implementation protocol, auto-gate, commit conventions, branch strategy.
 **Do not improvise — everything is documented there.**
 
 ### 3. Read the project context
@@ -25,44 +25,44 @@ Contains stack, URLs, deploy status, active backlog.
 gh issue view <N> --repo ecologicaleaving/<repo>
 ```
 
-Read everything: objective, context, AC, technical notes, mandatory checkpoints.
+Read everything: objective, context, AC, technical notes.
 
 ---
 
 ## ⛔ BINDING RULES
 
-### Mandatory Checkpoints
+### Mandatory Auto-Gate
 
-At every checkpoint defined in the issue, you must:
+Before pushing, verify autonomously:
+1. All AC satisfied
+2. Tests and build passed
+3. Security audit passed (`scripts/security-audit.sh`)
+4. PROJECT.md updated
+5. No anomalous files in commit
 
-1. **Post a comment on the issue** with this exact format:
+If all ok → proceed to push autonomously.
+If you find unresolvable problems → **STOP and notify Davide** on the issue:
 
 ```
-## ✅ Checkpoint N — <title>
+## ⚠️ Blocked — <problem title>
 
-**Status:** completed
-
-**What was done:**
+**What happened:**
 <description>
 
-**Test results (if applicable):**
-<results>
+**Cause:**
+<analysis>
 
-**Planned next step:**
-<what I would do next>
+**Options:**
+<what I could do>
 
-**Waiting for Claudio's confirmation before proceeding.**
+**Waiting for Davide's instructions.**
 ```
-
-2. **Stop and wait** for Claudio's reply on the issue
-3. Proceed **only** when Claudio writes "procedi" or "✅ procedi"
-4. If Claudio writes "bloccato" or asks for clarification → wait for instructions
 
 ### Branch
 
 - Always work on `feature/issue-N-slug` (or `fix/` or `improve/`)
 - NEVER commit directly to `main` or `master`
-- Branch already created by Claudio at start — use it
+- Create the branch at start: `git checkout -b feature/issue-N-slug`
 
 ### Commit
 
@@ -80,8 +80,7 @@ At every checkpoint defined in the issue, you must:
 
 Before pushing, verify:
 - [ ] All issue AC satisfied
-- [ ] All checkpoints completed and confirmed by Claudio
-- [ ] Test suite passed (lint, typecheck, unit, e2e)
+- [ ] Auto-gate passed (tests, build, security audit)
 - [ ] PROJECT.md updated
 - [ ] No anomalous files in commit
 - [ ] Correct branch (not master/main)

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -10,7 +10,7 @@ git submodule update --init --remote .workflow
 ### 2. Leggi le regole operative
 `.workflow/skills/issue-implement/SKILL.md`
 
-Contiene il protocollo checkpoint obbligatori, convenzioni commit, branch strategy.
+Contiene il protocollo di implementazione, auto-gate, convenzioni commit, branch strategy.
 **Non improvvisare — tutto è documentato lì.**
 
 ### 3. Leggi il contesto del progetto
@@ -23,44 +23,44 @@ Contiene stack, URL, stato deploy, backlog attivo.
 gh issue view <N> --repo ecologicaleaving/<repo>
 ```
 
-Leggi tutto: obiettivo, contesto, AC, note tecniche, checkpoint obbligatori.
+Leggi tutto: obiettivo, contesto, AC, note tecniche.
 
 ---
 
 ## ⛔ REGOLE VINCOLANTI
 
-### Checkpoint obbligatori
+### Auto-gate obbligatorio
 
-Ad ogni checkpoint definito nella issue, devi:
+Prima di pushare, verifica autonomamente:
+1. Tutti gli AC soddisfatti
+2. Test e build passati
+3. Security audit passato (`scripts/security-audit.sh`)
+4. PROJECT.md aggiornato
+5. Nessun file anomalo nel commit
 
-1. **Postare un commento sulla issue** con questo formato esatto:
+Se tutto ok → procedi al push autonomamente.
+Se trovi problemi non risolvibili → **FERMATI e notifica Davide** sulla issue con questo formato:
 
 ```
-## ✅ Checkpoint N — <titolo>
+## ⚠️ Blocco — <titolo problema>
 
-**Stato:** completato
-
-**Cosa è stato fatto:**
+**Cosa è successo:**
 <descrizione>
 
-**Risultati test (se applicabile):**
-<risultati>
+**Causa:**
+<analisi>
 
-**Prossimo step pianificato:**
-<cosa farei dopo>
+**Opzioni:**
+<cosa potrei fare>
 
-**Aspetto conferma di Claudio prima di procedere.**
+**In attesa di indicazioni da Davide.**
 ```
-
-2. **Fermarti e aspettare** la risposta di Claudio sulla issue
-3. Procedere **solo** quando Claudio scrive "procedi" o "✅ procedi"
-4. Se Claudio scrive "bloccato" o chiede chiarimenti → aspetta istruzioni
 
 ### Branch
 
 - Lavora sempre su `feature/issue-N-slug` (o `fix/` o `improve/`)
 - MAI commit diretti su `main` o `master`
-- Branch già creato da Claudio all'avvio — usa quello
+- Crea il branch all'inizio: `git checkout -b feature/issue-N-slug`
 
 ### Commit
 
@@ -78,8 +78,7 @@ Ad ogni checkpoint definito nella issue, devi:
 
 Prima di fare push, verifica:
 - [ ] Tutti gli AC della issue soddisfatti
-- [ ] Tutti i checkpoint completati e confermati da Claudio
-- [ ] Test suite passata (lint, typecheck, unit, e2e)
+- [ ] Auto-gate superato (test, build, security audit)
 - [ ] PROJECT.md aggiornato
 - [ ] Nessun file anomalo nel commit
 - [ ] Branch corretto (non master/main)

--- a/templates/issue-bug.md
+++ b/templates/issue-bug.md
@@ -57,7 +57,7 @@
 
 ## 📌 Checkpoint Obbligatori
 
-<!-- Generati da Claudio e approvati da Davide -->
+<!-- Generati dall'agente e approvati da Davide -->
 - [ ] **CP1 — Root Cause** → Agente identifica e riporta la causa del bug prima di toccare codice
 - [ ] **CP2 — Fix** → Report del fix applicato con test di regressione
 - [ ] **CP3 — Test Suite** → Risultati completi lint / typecheck / unit / e2e

--- a/templates/issue-feature.md
+++ b/templates/issue-feature.md
@@ -47,7 +47,7 @@
 
 ## 📌 Checkpoint Obbligatori
 
-<!-- Generati da Claudio e approvati da Davide -->
+<!-- Generati dall'agente e approvati da Davide -->
 - [ ] **CP1 — Piano** → Agente riporta piano + task checklist prima di scrivere codice
 - [ ] **CP2 — Implementazione** → Report dopo ogni iterazione con cosa è stato fatto e test result
 - [ ] **CP3 — Test Suite** → Risultati completi lint / typecheck / unit / e2e

--- a/templates/issue-improvement.md
+++ b/templates/issue-improvement.md
@@ -50,7 +50,7 @@
 
 ## 📌 Checkpoint Obbligatori
 
-<!-- Generati da Claudio e approvati da Davide -->
+<!-- Generati dall'agente e approvati da Davide -->
 - [ ] **CP1 — Piano** → Agente riporta piano + approccio + impatto stimato
 - [ ] **CP2 — Implementazione** → Report dopo ogni iterazione con misurazione risultati
 - [ ] **CP3 — Test Suite** → Risultati completi lint / typecheck / unit / e2e

--- a/templates/pull_request_template.md
+++ b/templates/pull_request_template.md
@@ -15,13 +15,12 @@
 
 ---
 
-## 📌 Checkpoint completati
+## 📌 Auto-gate superato
 
-<!-- Tutti i checkpoint della issue devono essere confermati da Claudio -->
-- [ ] CP1 — confermato da Claudio
-- [ ] CP2 — confermato da Claudio
-- [ ] CP3 — confermato da Claudio
-- [ ] CP4 — confermato da Claudio
+- [ ] Tutti gli AC verificati dall'agente
+- [ ] Test e build passati
+- [ ] Security audit passato
+- [ ] PROJECT.md aggiornato
 
 ---
 
@@ -66,4 +65,4 @@
 
 ---
 
-*PR verificata da Claudio — Workflow 80/20 Solutions v2.0*
+*PR generata dall'agente — Workflow 80/20 Solutions v4.0*


### PR DESCRIPTION
## Summary

- Workflow v4.0: ruoli ridotti a **Davide** (Product Owner) + **Agente** (Claude Code)
- L'agente gestisce in autonomia tutto il ciclo: issue, kanban, implementazione, PR, merge
- Auto-gate finale: l'agente si auto-valida e procede senza layer di supervisione intermedi
- Azioni infra VPS: elencate dall'agente, eseguite manualmente da Davide

## File modificati (34)

- `WORKFLOW.md`, `CLAUDE.md`, `README.md` — aggiornati a v4.0
- `skills/issue-validate`, `issue-implement`, `issue-pr-ready`, `issue-approve`, `issue-reject` — rimosso ruolo Claudio
- `templates/CLAUDE.md`, `templates/AGENTS.md` — auto-gate al posto di attesa conferma Claudio
- `templates/pull_request_template.md` — checkpoint → auto-gate
- File storici (`WORKFLOW_DAVID.md`, `workflow-rules.md`, `BRANCH_STRATEGY.md`) — avvisi di deprecazione

🤖 Generated with [Claude Code](https://claude.com/claude-code)