### PR TITLE
ci: replay build event perso per protezione branch (MaestroWeb #120)

### DIFF
--- a/notifications/build-log.jsonl
+++ b/notifications/build-log.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-04-17T05:26:49Z","repo":"ecologicaleaving/maestroweb","branch":"main","status":"success","sha":"2cd1560","url":"https://github.com/ecologicaleaving/maestroweb/actions/runs/24549258353","read":false}


### PR DESCRIPTION
## Problema

Il workflow \`📥 Receive Build Events\` fa \`git push\` direttamente su \`master\` usando \`GITHUB_TOKEN\`, ma \`master\` e' protetto (richiede PR + review). Il push fallisce con:

\`\`\`
remote: error: GH006: Protected branch update failed for refs/heads/master.
! [remote rejected] master -> master (protected branch hook declined)
\`\`\`

Poiche' lo step usa \`|| true\`, il workflow risulta "success" ma il dato non viene mai salvato. Il file \`notifications/build-log.jsonl\` non esiste sul remote.

## Evento perso

Il run **24549258353** di MaestroWeb (merge PR #120, sha \`2cd1560\`) ha completato con successo il 2026-04-17T05:26:49Z ma la notifica non e' mai arrivata a Davide.

## Fix in questa PR

Ripristino manuale della riga persa in \`notifications/build-log.jsonl\`.

## Nota

Una PR separata (\`fix/build-events-push\`) proporra' il fix strutturale al workflow per evitare che si ripeta. Non mergiarla senza approvazione di Davide.