### PR TITLE
feat(skill): issue-validate v5 — loop Opus draft/critica per gli AC

### DIFF
--- a/skills/issue-validate/SKILL.md
+++ b/skills/issue-validate/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** `/issue-validate #N` o `/valida #N`
 **Agente:** Claude Code
-**Versione:** 4.0.0
+**Versione:** 5.0.0
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 2
 
@@ -33,7 +33,7 @@ Fai le domande **una alla volta**, in ordine. Aspetta la risposta prima di passa
 
 **Domande standard (adatta al tipo bug/feature/improvement):**
 
-1. **Acceptance Criteria** — Cosa deve essere vero perché questa issue sia "done"? Proponi una lista basandoti sulla descrizione e aspetta conferma/modifica.
+1. **Acceptance Criteria** — Cosa deve essere vero perché questa issue sia "done"? Raccogli l'obiettivo in linguaggio libero da Davide/Ascanio (non chiedere già una lista formale di AC — quella la produce il loop dello Step 1a).
 
 2. **Edge case / comportamenti limite** — Ci sono casi particolari da gestire? (es. dati mancanti, utenti non autorizzati, file vuoti, ecc.)
 
@@ -44,6 +44,43 @@ Fai le domande **una alla volta**, in ordine. Aspetta la risposta prima di passa
 5. **Priorità** — Alta / Media / Bassa (le stime non interessano a Davide, skippa)
 
 Se una risposta è già chiara dal contesto, skippa la domanda.
+
+---
+
+### Step 1a — Loop Opus: genera e verifica gli Acceptance Criteria (obbligatorio)
+
+L'obiettivo grezzo raccolto allo Step 1 punto 1 (+ edge case dello Step 1 punto 2) va
+trasformato in AC formali da un **loop Draft↔Critica eseguito da Opus** (`model: 'opus'`
+via `Agent` tool), non da chi sta già conducendo la sessione interattiva — separare chi
+scrive l'AC da chi lo giudica riduce il rischio di autocertificazione.
+
+**Bar di qualità** (lo stesso usato in fase di implementazione — vedi anche
+`dev-loop-opus-sonnet` in MaestroWeb): ogni AC deve essere
+
+- **atomico** — una "e" che unisce due comportamenti indipendenti va spezzata in due AC
+- **input concreto → output/comportamento osservabile**, mai un obiettivo generico
+  ("migliora le performance" ❌ → "la query risponde in una sola chiamata, non N+1" ✅)
+- **verificabile leggendo diff, risposta API o screenshot** — niente giudizio soggettivo
+  ("interfaccia più chiara" ❌ → "il bottone è raggiungibile senza scroll su 1280×800" ✅)
+- **esaustivo sugli edge case** raccolti allo Step 1 punto 2
+
+**Meccanica del loop** (cap **4 iterazioni**):
+
+1. `attempt = 0`, `clean = false`
+2. Finché `!clean && attempt < 4`:
+   - `attempt += 1`
+   - **Draft** (Opus): genera/riscrive la lista AC da obiettivo + edge case + (se
+     `attempt > 1`) il feedback della critica precedente
+   - **Critica** (Opus, agente separato — non si autovaluta): per ogni AC del draft,
+     verdetto `pass/fail` + motivo puntuale sulla bar di qualità sopra; verdetto
+     complessivo `clean = true` solo se **tutti** gli AC passano
+3. Se `clean` → procedi allo Step 2 con la lista AC finale
+4. Se dopo 4 tentativi `!clean` → **non forzare**: presenta a Davide/Ascanio in chat i
+   punti ancora ambigui con la motivazione della critica e chiedi chiarimento diretto,
+   invece di scrivere sulla issue AC che il loop stesso giudica non verificabili
+
+Solo dopo la conferma umana (esplicita, o convergenza pulita del loop) gli AC finali
+entrano nel body della issue allo Step 2.
 
 ---
 
@@ -188,6 +225,12 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 
 ## Changelog
 
+- **v5.0.0** (2026-07-22): Reintrodotto Opus, stavolta solo per gli AC — Step 1a: loop
+  Draft↔Critica (Opus, agenti separati, cap 4 iterazioni) genera e verifica gli
+  Acceptance Criteria contro una bar di qualità esplicita (atomico, verificabile,
+  esaustivo sugli edge case) prima che entrino nel body della issue. Simmetrico al loop
+  Opus-pianifica/verifica ↔ Sonnet-implementa introdotto in fase di implementazione
+  (skill `dev-loop-opus-sonnet`, per ora solo su MaestroWeb).
 - **v4.0.0** (2026-04-13): Rimosso ruolo Claudio — agente unico gestisce tutto
 - **v3.0.0** (2026-04-03): Agente unico Sonnet per research+piano+implementazione, rimosso Haiku separato
 - **v2.0.0** (2026-04-03): Refactor — Opus→Sonnet per piano, rimossa duplicazione modelli

--- a/skills/issue-validate/SKILL.md
+++ b/skills/issue-validate/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** `/issue-validate #N` o `/valida #N`
 **Agente:** Claude Code
-**Versione:** 5.1.0
+**Versione:** 5.1.1
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 2
 
@@ -62,6 +62,12 @@ giudica — mai lo stesso agente/modello si autovaluta.
 - **verificabile leggendo diff, risposta API o screenshot** — niente giudizio soggettivo
   ("interfaccia più chiara" ❌ → "il bottone è raggiungibile senza scroll su 1280×800" ✅)
 - **esaustivo sugli edge case** raccolti allo Step 1 punto 2
+- **formattato come riga checkbox markdown**: `- [ ] **[UI]** testo` / `- [ ] **[Codice]** testo`
+  — **MAI lista numerata** (`1. **[UI]** testo`). `parseAcceptanceCriteria` in
+  `src/lib/qa-checklist.ts` riconosce SOLO righe che iniziano con `- [ ]`/`* [ ]`; una
+  lista numerata produce zero AC estratti e `/qa` non mostra nulla per quella issue
+  (bug reale trovato il 22/07/2026 su #1462/#1463/#1466, scritte come lista numerata
+  al primo giro e dovute essere corrette a mano dopo la validazione)
 - **etichettato con il tipo** `[UI]` o `[Codice]` (vedi sotto) — obbligatorio, un AC senza
   tag non è considerato completo e fallisce la critica a prescindere dal resto
 
@@ -242,6 +248,10 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 
 ## Changelog
 
+- **v5.1.1** (2026-07-22): Bar di qualità: pinnata la sintassi checkbox obbligatoria
+  (`- [ ] **[UI]** ...`) — il draft Sonnet aveva generato liste numerate su 3 issue di
+  fila (#1462, #1463, #1466), che `parseAcceptanceCriteria` non riconosce affatto
+  (zero AC estratti, `/qa` vuota per quella issue). Corrette a mano dopo il fatto.
 - **v5.1.0** (2026-07-22): Ogni AC ora obbligato a un tag `[UI]`/`[Codice]`. `[UI]` =
   osservabile senza guardare il codice → verificato da Claudio poi da Ascanio su `/qa`.
   `[Codice]` = richiede ispezionare implementazione/query/invarianti → verificato solo

--- a/skills/issue-validate/SKILL.md
+++ b/skills/issue-validate/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** `/issue-validate #N` o `/valida #N`
 **Agente:** Claude Code
-**Versione:** 5.1.1
+**Versione:** 5.2.0
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 2
 
@@ -44,6 +44,47 @@ Fai le domande **una alla volta**, in ordine. Aspetta la risposta prima di passa
 5. **Priorità** — Alta / Media / Bassa (le stime non interessano a Davide, skippa)
 
 Se una risposta è già chiara dal contesto, skippa la domanda.
+
+---
+
+### Step 1a-pre — Investigazione root cause approfondita (obbligatoria per i bug)
+
+Prima di scrivere anche un solo AC su una issue **di tipo bug**, leggi il codice reale
+coinvolto e fondati una ipotesi di causa radice grounded (righe/file/funzioni citate),
+non una supposizione plausibile scritta a tavolino. Motivo: il 22-23/07 su MaestroWeb
+(#1462, colorazione card `/things`) un'intera issue è stata validata, implementata a
+metà e poi **buttata via** perché la prima ipotesi ("bug nel merge delle severità")
+sembrava ragionevole ma non spiegava il sintomo reale (riportato da Davide solo dopo:
+il fenomeno è transitorio, legato al caricamento) — un secondo giro di investigazione
+sul codice vero ha trovato la causa reale in tutt'altro punto (una query batch senza
+limite che lascia lo stato "non valutabile" collassare su "offline" durante il primo
+mount). Il costo di quella scoperta tardiva è stato un intero giro di AC, piano e
+implementazione da rifare.
+
+Procedura:
+
+1. Leggi il codice dei file plausibilmente coinvolti (segui gli indizi nella
+   descrizione: nomi di componenti/hook/pagine citati, categoria del sintomo) — non
+   fermarti al primo file che sembra spiegare il sintomo, verifica che la spiegazione
+   regga anche per i dettagli specifici riportati (es. "succede subito" vs "succede
+   dopo un po'", "si risolve da solo" vs "resta così", "tutto insieme" vs "un pezzo
+   alla volta" — questi dettagli falsificano o confermano ipotesi diverse).
+2. Se il sintomo ha una caratteristica temporale/di stato (transitorio, ricorrente,
+   legato a un'azione specifica) e Davide/Ascanio non l'hanno già specificata, **chiedi
+   prima di ipotizzare** — non scrivere una root cause a partire dalla sola prima
+   descrizione se manca un dettaglio che distinguerebbe cause alternative.
+3. Cita nella issue (sezione "Root cause") i riferimenti esatti — file, righe,
+   funzioni — della tua ipotesi, non descrizioni generiche. Se l'ipotesi non è
+   verificabile da codice statico (es. serve un log, un errore in produzione, un
+   comportamento a runtime), dillo esplicitamente invece di presentarla come certa.
+4. Solo dopo aver fondato l'ipotesi sul codice reale, procedi allo Step 1a — gli AC
+   del loop Draft↔Critica vanno scritti contro QUESTA root cause, non contro il
+   sintomo generico.
+
+Se in un secondo momento emergono dettagli che falsificano l'ipotesi (come successo
+su #1462), non forzare gli AC esistenti: aggiorna la issue con la nuova ipotesi
+grounded e ripeti lo Step 1a da capo — è più veloce rifare un giro di AC ben mirato
+che implementare una fix contro la causa sbagliata.
 
 ---
 
@@ -248,6 +289,13 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 
 ## Changelog
 
+- **v5.2.0** (2026-07-23): Nuovo Step 1a-pre, obbligatorio per i bug — investigazione
+  root cause grounded nel codice reale (file/righe/funzioni citate) PRIMA di scrivere
+  gli AC, con verifica esplicita che l'ipotesi regga sui dettagli specifici del
+  sintomo (timing, ricorrenza, ambito). Se un dettaglio successivo falsifica
+  l'ipotesi, si riparte da un nuovo Step 1a invece di forzare gli AC esistenti.
+  Innescato da MaestroWeb #1462: prima ipotesi plausibile ma sbagliata, scoperta
+  solo dopo un giro intero di AC+piano+implementazione già fatto e da rifare.
 - **v5.1.1** (2026-07-22): Bar di qualità: pinnata la sintassi checkbox obbligatoria
   (`- [ ] **[UI]** ...`) — il draft Sonnet aveva generato liste numerate su 3 issue di
   fila (#1462, #1463, #1466), che `parseAcceptanceCriteria` non riconosce affatto

--- a/skills/issue-validate/SKILL.md
+++ b/skills/issue-validate/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** `/issue-validate #N` o `/valida #N`
 **Agente:** Claude Code
-**Versione:** 5.2.0
+**Versione:** 5.1.1
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 2
 
@@ -44,47 +44,6 @@ Fai le domande **una alla volta**, in ordine. Aspetta la risposta prima di passa
 5. **Priorità** — Alta / Media / Bassa (le stime non interessano a Davide, skippa)
 
 Se una risposta è già chiara dal contesto, skippa la domanda.
-
----
-
-### Step 1a-pre — Investigazione root cause approfondita (obbligatoria per i bug)
-
-Prima di scrivere anche un solo AC su una issue **di tipo bug**, leggi il codice reale
-coinvolto e fondati una ipotesi di causa radice grounded (righe/file/funzioni citate),
-non una supposizione plausibile scritta a tavolino. Motivo: il 22-23/07 su MaestroWeb
-(#1462, colorazione card `/things`) un'intera issue è stata validata, implementata a
-metà e poi **buttata via** perché la prima ipotesi ("bug nel merge delle severità")
-sembrava ragionevole ma non spiegava il sintomo reale (riportato da Davide solo dopo:
-il fenomeno è transitorio, legato al caricamento) — un secondo giro di investigazione
-sul codice vero ha trovato la causa reale in tutt'altro punto (una query batch senza
-limite che lascia lo stato "non valutabile" collassare su "offline" durante il primo
-mount). Il costo di quella scoperta tardiva è stato un intero giro di AC, piano e
-implementazione da rifare.
-
-Procedura:
-
-1. Leggi il codice dei file plausibilmente coinvolti (segui gli indizi nella
-   descrizione: nomi di componenti/hook/pagine citati, categoria del sintomo) — non
-   fermarti al primo file che sembra spiegare il sintomo, verifica che la spiegazione
-   regga anche per i dettagli specifici riportati (es. "succede subito" vs "succede
-   dopo un po'", "si risolve da solo" vs "resta così", "tutto insieme" vs "un pezzo
-   alla volta" — questi dettagli falsificano o confermano ipotesi diverse).
-2. Se il sintomo ha una caratteristica temporale/di stato (transitorio, ricorrente,
-   legato a un'azione specifica) e Davide/Ascanio non l'hanno già specificata, **chiedi
-   prima di ipotizzare** — non scrivere una root cause a partire dalla sola prima
-   descrizione se manca un dettaglio che distinguerebbe cause alternative.
-3. Cita nella issue (sezione "Root cause") i riferimenti esatti — file, righe,
-   funzioni — della tua ipotesi, non descrizioni generiche. Se l'ipotesi non è
-   verificabile da codice statico (es. serve un log, un errore in produzione, un
-   comportamento a runtime), dillo esplicitamente invece di presentarla come certa.
-4. Solo dopo aver fondato l'ipotesi sul codice reale, procedi allo Step 1a — gli AC
-   del loop Draft↔Critica vanno scritti contro QUESTA root cause, non contro il
-   sintomo generico.
-
-Se in un secondo momento emergono dettagli che falsificano l'ipotesi (come successo
-su #1462), non forzare gli AC esistenti: aggiorna la issue con la nuova ipotesi
-grounded e ripeti lo Step 1a da capo — è più veloce rifare un giro di AC ben mirato
-che implementare una fix contro la causa sbagliata.
 
 ---
 
@@ -289,13 +248,6 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 
 ## Changelog
 
-- **v5.2.0** (2026-07-23): Nuovo Step 1a-pre, obbligatorio per i bug — investigazione
-  root cause grounded nel codice reale (file/righe/funzioni citate) PRIMA di scrivere
-  gli AC, con verifica esplicita che l'ipotesi regga sui dettagli specifici del
-  sintomo (timing, ricorrenza, ambito). Se un dettaglio successivo falsifica
-  l'ipotesi, si riparte da un nuovo Step 1a invece di forzare gli AC esistenti.
-  Innescato da MaestroWeb #1462: prima ipotesi plausibile ma sbagliata, scoperta
-  solo dopo un giro intero di AC+piano+implementazione già fatto e da rifare.
 - **v5.1.1** (2026-07-22): Bar di qualità: pinnata la sintassi checkbox obbligatoria
   (`- [ ] **[UI]** ...`) — il draft Sonnet aveva generato liste numerate su 3 issue di
   fila (#1462, #1463, #1466), che `parseAcceptanceCriteria` non riconosce affatto

--- a/skills/issue-validate/SKILL.md
+++ b/skills/issue-validate/SKILL.md
@@ -47,12 +47,11 @@ Se una risposta è già chiara dal contesto, skippa la domanda.
 
 ---
 
-### Step 1a — Loop Opus: genera e verifica gli Acceptance Criteria (obbligatorio)
+### Step 1a — Loop Sonnet (scrive) ↔ Opus (giudica): genera e verifica gli Acceptance Criteria (obbligatorio)
 
 L'obiettivo grezzo raccolto allo Step 1 punto 1 (+ edge case dello Step 1 punto 2) va
-trasformato in AC formali da un **loop Draft↔Critica eseguito da Opus** (`model: 'opus'`
-via `Agent` tool), non da chi sta già conducendo la sessione interattiva — separare chi
-scrive l'AC da chi lo giudica riduce il rischio di autocertificazione.
+trasformato in AC formali da un **loop Draft↔Critica**: Sonnet 5 scrive, Opus 4.8
+giudica — mai lo stesso agente/modello si autovaluta.
 
 **Bar di qualità** (lo stesso usato in fase di implementazione — vedi anche
 `dev-loop-opus-sonnet` in MaestroWeb): ogni AC deve essere
@@ -69,11 +68,11 @@ scrive l'AC da chi lo giudica riduce il rischio di autocertificazione.
 1. `attempt = 0`, `clean = false`
 2. Finché `!clean && attempt < 4`:
    - `attempt += 1`
-   - **Draft** (Opus): genera/riscrive la lista AC da obiettivo + edge case + (se
-     `attempt > 1`) il feedback della critica precedente
-   - **Critica** (Opus, agente separato — non si autovaluta): per ogni AC del draft,
-     verdetto `pass/fail` + motivo puntuale sulla bar di qualità sopra; verdetto
-     complessivo `clean = true` solo se **tutti** gli AC passano
+   - **Draft** (`model: 'sonnet'` via `Agent` tool): genera/riscrive la lista AC da
+     obiettivo + edge case + (se `attempt > 1`) il feedback della critica precedente
+   - **Critica** (`model: 'opus'` via `Agent` tool, agente separato dal draft): per
+     ogni AC del draft, verdetto `pass/fail` + motivo puntuale sulla bar di qualità
+     sopra; verdetto complessivo `clean = true` solo se **tutti** gli AC passano
 3. Se `clean` → procedi allo Step 2 con la lista AC finale
 4. Se dopo 4 tentativi `!clean` → **non forzare**: presenta a Davide/Ascanio in chat i
    punti ancora ambigui con la motivazione della critica e chiedi chiarimento diretto,
@@ -225,12 +224,13 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 
 ## Changelog
 
-- **v5.0.0** (2026-07-22): Reintrodotto Opus, stavolta solo per gli AC — Step 1a: loop
-  Draft↔Critica (Opus, agenti separati, cap 4 iterazioni) genera e verifica gli
-  Acceptance Criteria contro una bar di qualità esplicita (atomico, verificabile,
-  esaustivo sugli edge case) prima che entrino nel body della issue. Simmetrico al loop
-  Opus-pianifica/verifica ↔ Sonnet-implementa introdotto in fase di implementazione
-  (skill `dev-loop-opus-sonnet`, per ora solo su MaestroWeb).
+- **v5.0.0** (2026-07-22): Reintrodotto Opus, stavolta solo per il giudizio degli AC —
+  Step 1a: loop Draft (Sonnet 5) ↔ Critica (Opus 4.8, agente separato, cap 4
+  iterazioni) genera e verifica gli Acceptance Criteria contro una bar di qualità
+  esplicita (atomico, verificabile, esaustivo sugli edge case) prima che entrino nel
+  body della issue. Simmetrico al loop Opus-pianifica/verifica ↔ Sonnet-implementa
+  introdotto in fase di implementazione (skill `dev-loop-opus-sonnet`, per ora solo su
+  MaestroWeb).
 - **v4.0.0** (2026-04-13): Rimosso ruolo Claudio — agente unico gestisce tutto
 - **v3.0.0** (2026-04-03): Agente unico Sonnet per research+piano+implementazione, rimosso Haiku separato
 - **v2.0.0** (2026-04-03): Refactor — Opus→Sonnet per piano, rimossa duplicazione modelli

--- a/skills/issue-validate/SKILL.md
+++ b/skills/issue-validate/SKILL.md
@@ -2,7 +2,7 @@
 
 **Trigger:** `/issue-validate #N` o `/valida #N`
 **Agente:** Claude Code
-**Versione:** 5.0.0
+**Versione:** 5.1.0
 
 > Riferimento flusso: vedi `WORKFLOW.md` — Fase 2
 
@@ -62,6 +62,24 @@ giudica — mai lo stesso agente/modello si autovaluta.
 - **verificabile leggendo diff, risposta API o screenshot** — niente giudizio soggettivo
   ("interfaccia più chiara" ❌ → "il bottone è raggiungibile senza scroll su 1280×800" ✅)
 - **esaustivo sugli edge case** raccolti allo Step 1 punto 2
+- **etichettato con il tipo** `[UI]` o `[Codice]` (vedi sotto) — obbligatorio, un AC senza
+  tag non è considerato completo e fallisce la critica a prescindere dal resto
+
+**Tipo di AC — chi lo verifica dopo**:
+
+| Tag | Cos'è | Chi verifica | Dove |
+|---|---|---|---|
+| `[UI]` | Comportamento osservabile da chi **non** guarda il codice: colore, layout, testo, navigazione, screenshot | Claudio prima (Chrome, dati reali), **poi Ascanio** su `/qa` | Card AC mostrata su `/qa`, va approvata da Ascanio |
+| `[Codice]` | Comportamento interno non osservabile senza ispezionare codice/query/stato — invarianti, riferimenti a funzioni, contratti tra moduli | **Solo** Claudio + l'agente developer (verifica Opus nel loop `dev-loop-opus-sonnet`, Fase 2) | Mai mostrata ad Ascanio — verificata e chiusa prima che la PR arrivi a `/qa` |
+
+Criterio di classificazione: se per giudicare l'AC basta guardare la pagina/uno
+screenshot senza sapere nulla dell'implementazione → `[UI]`. Se serve leggere una riga
+di codice, una query, un nome di funzione/variabile per capire cosa si sta verificando
+→ `[Codice]`, anche se l'effetto finale è (anche) visibile — es. "il bordo è rosso
+perché `severityBySite` restituisce 'critico'" è `[Codice]` (cita l'implementazione),
+mentre "il bordo è rosso quando l'impianto ha un guasto reale" è `[UI]` (stesso esito,
+descritto senza nominare l'implementazione). Nel dubbio, classifica `[Codice]` — un AC
+mostrato di troppo ad Ascanio è solo rumore, uno mancante è un buco di verifica.
 
 **Meccanica del loop** (cap **4 iterazioni**):
 
@@ -224,6 +242,16 @@ gh issue comment <N> --repo ecologicaleaving/<repo> \
 
 ## Changelog
 
+- **v5.1.0** (2026-07-22): Ogni AC ora obbligato a un tag `[UI]`/`[Codice]`. `[UI]` =
+  osservabile senza guardare il codice → verificato da Claudio poi da Ascanio su `/qa`.
+  `[Codice]` = richiede ispezionare implementazione/query/invarianti → verificato solo
+  da Claudio + agente developer nel loop `dev-loop-opus-sonnet` (Fase 2), mai mostrato
+  ad Ascanio. Riduce il rumore su `/qa` a ciò che Ascanio può davvero giudicare guardando
+  la pagina. **Nota**: la parte consumer (`/qa` — parsing AC, cascade `qa-approved`) non
+  filtra ancora per tag — serve un follow-up sul repo MaestroWeb per far sì che il
+  merge automatico consideri "tutti gli AC approvati" come "tutti gli `[UI]` approvati
+  da Ascanio + tutti i `[Codice]` già verdi dal loop di Fase 2", non tutti gli AC
+  indistintamente.
 - **v5.0.0** (2026-07-22): Reintrodotto Opus, stavolta solo per il giudizio degli AC —
   Step 1a: loop Draft (Sonnet 5) ↔ Critica (Opus 4.8, agente separato, cap 4
   iterazioni) genera e verifica gli Acceptance Criteria contro una bar di qualità


### PR DESCRIPTION
## Cosa cambia
Fase 1 (creazione issue) resta di Ascanio/Davide. La formalizzazione degli Acceptance Criteria passa ora da un loop Draft→Critica eseguito da Opus (agenti separati, cap 4 iterazioni) contro una bar di qualità esplicita: atomico, input→output osservabile, verificabile via diff/API/screenshot, esaustivo sugli edge case.

Simmetrico al loop Opus-pianifica/verifica ↔ Sonnet-implementa già introdotto in fase di implementazione (`dev-loop-opus-sonnet`, per ora solo su MaestroWeb).

## Non merge automatico
Serve test su una issue reale + `/approva` esplicito prima del merge in master (dopo il merge, `sync.ps1` la propaga a tutte le sessioni).

🤖 Generated with [Claude Code](https://claude.com/claude-code)