### PR TITLE
feat(skill): security-review-platform — audit di postura su progetti in produzione

### DIFF
--- a/skills/security-review-platform/SKILL.md
+++ b/skills/security-review-platform/SKILL.md
@@ -1,0 +1,141 @@
+# Skill: security-review-platform
+
+**Trigger:** `/security-review` su un progetto già in produzione, oppure quando Davide chiede «facciamo i controlli di sicurezza su X».
+**Agente:** qualsiasi agente tecnico.
+**Versione:** 1.0.0 — derivata dall'epic #634 su MaestroWeb (26-28/07/2026), dove questo metodo ha trovato 2 finding critici e 6 alti.
+
+> Diversa da `security-audit`, che è il gate **pre-push** su un diff (secrets, dipendenze, debug leftover). Questa è una **review di postura** su un sistema già vivo.
+
+---
+
+## Il principio, prima di tutto
+
+**Un audit fatto leggendo il codice produce falsi negativi.** Non è un'opinione: sull'epic #634 *ogni* finding grave era invisibile nel codice.
+
+| Cosa sembrava | Cosa era |
+|---|---|
+| Le migration mostravano policy RLS corrette | 6 tabelle erano leggibili da chiunque senza login — le policy vere non stavano nelle migration |
+| `iptables -L` mostrava una regola DROP attiva sulla porta | La porta era aperta: la regola non poteva matchare |
+| Il `systemd` timer risultava `enabled` e `active` | Non era scattato nemmeno una volta |
+| Gli header di sicurezza erano nella config nginx | Gli asset statici uscivano senza nemmeno uno |
+| Le credenziali erano documentate come «ambiente di test» | Aprivano la produzione, con privilegi di superadmin |
+
+**Regola operativa: ogni finding va verificato dall'esterno, con una richiesta reale.** Se non hai provato, non l'hai verificato — scrivi «non verificato», non dedurre.
+
+---
+
+## Fase 1 — Superficie dati (la più importante)
+
+Su Supabase/PostgREST, o qualunque backend con API generata dallo schema.
+
+**Cosa fare**: prendere la chiave pubblica del progetto (`NEXT_PUBLIC_*_ANON_KEY`, sta nel bundle JS: è pubblica per costruzione) e provare a leggere **ogni tabella** senza login.
+
+```bash
+curl -s "$URL/rest/v1/<tabella>?select=*&limit=1" -H "apikey: $ANON_KEY"
+```
+
+Righe restituite = leak. `[]` o `42501` = protetta.
+
+**Due cause ricorrenti, entrambe viste in produzione:**
+
+1. **RLS mai abilitata**, con la motivazione «questa tabella la usa solo il service_role». È falsa: ogni tabella in `public` ha un GRANT di default per `anon`/`authenticated` ed è esposta via PostgREST, indipendentemente da chi la usa *davvero*.
+2. **`FOR ALL USING (true)` senza clausola `TO`**. Senza `TO` la policy vale per `PUBLIC`, cioè anche `anon`. Il caso reale si chiamava `service_role_full_access` e di service_role aveva solo il nome. Al service_role una policy **non serve mai**: bypassa RLS per definizione. Se ne stai scrivendo una, o è inutile o sta aprendo a chiunque.
+
+**Poi verifica la scrittura**, non solo la lettura — ma con un filtro su un ID inesistente, così tocchi 0 righe. **Attenzione**: un `204` su 0 righe **non prova** il permesso, perché RLS filtra le righe e non rifiuta l'operazione. Prova il GRANT, non la policy. Distinguere, o si producono finding falsi.
+
+**Le view non ereditano la RLS della tabella base**: mettere in sicurezza la tabella non chiude la view. Serve `security_invoker = on`.
+
+**Se il ruolo di test è admin/superadmin, la verifica non vale.** Le policy hanno forma `is_superadmin() OR <scope>`: con un account god il secondo ramo non viene mai valutato, e un errore nello scope resta invisibile. Serve un utente normale. Se non c'è, **dichiaralo come limite** invece di far finta di aver verificato.
+
+## Fase 2 — Credenziali nel repo
+
+```bash
+git ls-files | ... # cerca su file VERSIONATI, non sul working dir
+```
+
+Cerca: password in chiaro, JWT, API key provider, chiavi private.
+
+**Sui JWT, decodifica il payload**: una chiave `anon` è pubblica e non è un finding; una `service_role` è critica. Segnalare ogni stringa `eyJ` genera rumore e fa ignorare il report.
+
+**La domanda che conta non è «è una credenziale di test?», è «funziona in produzione?».** Provala. Nel caso reale la password era documentata come ambiente di test da 4 mesi e apriva la produzione con privilegi di superadmin.
+
+**Rimuoverla dal codice non basta**: resta nella history git. Va **ruotata**. Se il report non lo dice esplicitamente, il problema resta aperto anche a PR mergiata.
+
+## Fase 3 — Header e TLS
+
+Verifica gli header **su una pagina HTML e su un asset statico**, separatamente.
+
+```bash
+curl -sSI https://sito/una-pagina
+curl -sSI https://sito/_next/static/chunks/qualcosa.js
+```
+
+In nginx **`add_header` non si eredita** in una `location` che ne dichiara uno proprio. Una location che imposta `Cache-Control` sugli asset perde *tutti* gli header di sicurezza. Nel caso reale il file documentava il gotcha in un commento e lo applicava a metà.
+
+Confronta **prod e test fra loro**: le configurazioni divergono nel tempo e la differenza segnala quale delle due è indietro.
+
+Una **CSP** va introdotta in `Content-Security-Policy-Report-Only`: se sbagliata rompe l'app in silenzio.
+
+Se davanti c'è Cloudflare, il certificato che vedi è il suo: **il tratto Cloudflare→origin dipende dalla modalità SSL nel pannello**. Se non è *Full (strict)*, quel tratto è debole. Richiede il pannello, non è deducibile da fuori.
+
+## Fase 4 — Auth
+
+```
+durata access token, presenza refresh token
+dopo il logout: l'access token è davvero revocato? il refresh è invalidato?
+messaggi d'errore per account esistente vs inesistente: identici?
+```
+
+Verifica dove sta la sessione: in `localStorage` è esposta a XSS — e va letta **insieme** all'assenza di CSP e di MFA. Tre finding "medi" separati possono essere una catena completa.
+
+**Sul rate limiting sii onesto**: pochi tentativi non dimostrano che non esista un limite. Leggilo dalla configurazione, non dedurlo a colpi di richieste su un endpoint di produzione.
+
+## Fase 5 — GDPR
+
+Inventario delle tabelle con dati personali, retention, cancellazione, trasferimenti a terzi.
+
+**Due cose che non si vedono guardando lo schema:**
+
+- **Un campo "tecnico" può essere un dato personale.** Nel caso reale `sites.name` conteneva nomi e cognomi di clienti: ogni log, ogni notifica esterna che includeva quel campo trattava dati personali.
+- **La telemetria a granularità fine rivela abitudini di vita.** Una curva di consumo a 15 minuti dice quando qualcuno è in casa. Non è un dato tecnico neutro.
+
+Controlla dove finiscono i dati: un'integrazione che manda documenti a un servizio LLM è un **trasferimento a terzi**, spesso extra-UE.
+
+Il **diritto di cancellazione** non è una `DELETE`: va deciso per ogni tabella fra cancellare e **anonimizzare**, perché i log di comando hanno valore di audit. Se non c'è, apri una issue dedicata invece di improvvisarlo.
+
+## Fase 6 — Infrastruttura (se il progetto ha un VPS)
+
+```bash
+sshd -T | grep -E 'permitrootlogin|passwordauthentication'
+ufw status
+systemctl is-active fail2ban unattended-upgrades
+ss -tlnp        # cosa ascolta
+```
+
+Poi **verifica dall'esterno** quali porte rispondono davvero: `ss` dice cosa ascolta, non cosa è raggiungibile.
+
+**Docker pubblica su `0.0.0.0` bypassando UFW.** Il filtro va in `DOCKER-USER`, e lì:
+
+- usa **`-m conntrack --ctorigdstport`**, mai `--dport`: quando il pacchetto arriva il DNAT è già avvenuto, quindi `--dport` vede la porta *interna* del container. Funziona per caso quando le due coincidono (`8080->8080`) e fallisce in silenzio quando differiscono (`3007->3000`), lasciando una regola perfettamente visibile in `iptables -L` che non filtra niente.
+- **verifica che le regole siano persistite.** Nel caso reale proteggevano i database di 3 progetti ed esistevano solo in memoria: al primo reboot sarebbero finiti su internet. `iptables -L` non lo dice.
+
+Se aggiungi un timer systemd di recupero: **niente `RemainAfterExit=yes`** (systemd non rilancia un service già `active`, e il timer non scatta mai) e usa `OnCalendar` invece di `OnUnitActiveSec`. **Poi provalo**: cancella una regola a mano e guarda se torna.
+
+Attenzione: `systemctl restart docker` **non riporta su tutti i container** — mettilo in conto prima di lanciarlo su una macchina condivisa fra progetti.
+
+---
+
+## Come riportare
+
+Un finding utile ha tre parti: **cosa**, **come l'hai verificato**, **quanto è grave davvero**.
+
+- Classifica per severità reale, non teorica. Una console admin esposta con credenziali di fabbrica sembra critica; se il servizio dietro è vuoto e inattivo, è alta ma non critica — e dirlo mantiene credibile il resto del report.
+- **Separa i finding dalle azioni che spettano ai fondatori.** Rotazione credenziali, pannelli esterni, decisioni di retention: l'agente non può eseguirle, e se restano annegate nel report non le fa nessuno. Elencale a parte.
+- **Marca esplicitamente ciò che non hai potuto provare.** «Non verificato» è un esito legittimo; una deduzione presentata come verifica no.
+- Se il fix richiede di toccare infrastruttura, consegna uno script **idempotente**, con rollback in testa, e usa **path assoluti** (uno script consegnato con path relativo è già fallito due volte in silenzio).
+
+## Cosa lasciare al progetto
+
+Non solo il report: uno **strumento che rileva la classe di problema**, agganciato a `package.json` e con exit code 1 per la CI. Su MaestroWeb sono `npm run audit:rls` e `npm run audit:secrets` (`scripts/security-audit-*.mjs`) — copiabili e adattabili: cambiano solo il path delle migration e del file di ambiente.
+
+Uno strumento con **allowlist motivata** ha due effetti: la regressione si vede da sola, e le eccezioni intenzionali (una tabella pubblica per scelta) smettono di essere rumore che fa ignorare il check.

--- a/skills/security-review-platform/security-audit-rls.mjs
+++ b/skills/security-review-platform/security-audit-rls.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * security-audit-rls.mjs — audit della superficie esposta al ruolo `anon` (issue #1391, epic #634).
+ *
+ * Due controlli complementari:
+ *
+ *   STATICO   sulle migration: tabelle create senza ENABLE ROW LEVEL SECURITY,
+ *             policy `USING(true)` senza clausola `TO`, funzioni SECURITY DEFINER
+ *             senza `SET search_path`.
+ *   RUNTIME   contro il DB reale con la sola anon key: quali tabelle restituiscono
+ *             davvero righe a un client non autenticato.
+ *
+ * Il controllo statico da solo NON basta: le policy applicate a mano in produzione
+ * non compaiono nelle migration, e viceversa. Il leak di #1391 è stato trovato dal
+ * runtime, non dallo statico.
+ *
+ * Uso:
+ *   node scripts/security-audit-rls.mjs            # statico + runtime (serve .env.local)
+ *   node scripts/security-audit-rls.mjs --static   # solo statico, nessuna rete
+ *
+ * Exit code 1 se trova una violazione fuori allowlist → utilizzabile in CI.
+ * La logica di parsing è esportata (`analyzeMigrations`) ed è coperta da
+ * scripts/__tests__/security-audit-rls.test.mjs.
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const MIGRATIONS = join(ROOT, 'supabase', 'migrations');
+
+/**
+ * Tabelle/view la cui lettura da parte di `anon` è INTENZIONALE.
+ * Aggiungere una voce qui è una decisione di sicurezza: motivare sempre.
+ */
+export const ANON_READ_ALLOWLIST = {
+  electricity_prices: 'Prezzi zonali PUN/GME — dato pubblico, nessuna informazione su clienti o impianti.',
+};
+
+/**
+ * Analizza il contenuto delle migration e restituisce i finding.
+ * Funzione pura: riceve una mappa { nomeFile: contenutoSql }, non tocca il filesystem.
+ *
+ * @param {Record<string, string>} fileMap  migration in ordine di applicazione
+ * @param {Record<string, string>} allowlist tabelle pubbliche per scelta
+ */
+export function analyzeMigrations(fileMap, allowlist = ANON_READ_ALLOWLIST) {
+  const tables = new Map();
+  const t = (n) => {
+    const k = n.replace(/^public\./, '').replace(/"/g, '').toLowerCase();
+    if (!tables.has(k)) tables.set(k, { rls: null, policies: new Map(), created: null });
+    return tables.get(k);
+  };
+  const unsafeDefiners = [];
+
+  for (const f of Object.keys(fileMap).sort()) {
+    const sql = fileMap[f].replace(/--[^\n]*/g, '');
+
+    // Gli statement vanno applicati IN ORDINE: il pattern idempotente
+    // "DROP POLICY IF EXISTS x; CREATE POLICY x" darebbe zero policy se
+    // processassimo tutti i CREATE prima di tutti i DROP.
+    const ordered = [
+      ...sql.matchAll(/create\s+table\s+(?:if\s+not\s+exists\s+)?([\w."]+)/gi),
+      ...sql.matchAll(/alter\s+table\s+(?:if\s+exists\s+)?([\w."]+)\s+(enable|disable)\s+row\s+level\s+security/gi),
+      ...sql.matchAll(/create\s+policy\s+("[^"]+"|[\w]+)\s+on\s+([\w."]+)([\s\S]*?);/gi),
+      ...sql.matchAll(/drop\s+policy\s+(?:if\s+exists\s+)?("[^"]+"|[\w]+)\s+on\s+([\w."]+)/gi),
+    ].sort((a, b) => a.index - b.index);
+
+    for (const m of ordered) {
+      if (/^create\s+table/i.test(m[0])) {
+        const e = t(m[1]); if (!e.created) e.created = f;
+      } else if (/row\s+level\s+security/i.test(m[0])) {
+        t(m[1]).rls = m[2].toLowerCase() === 'enable';
+      } else if (/^create\s+policy/i.test(m[0])) {
+        const name = m[1].replace(/"/g, '');
+        const body = m[3];
+        const to = (body.match(/\bto\s+([\w,\s]+?)(?:\busing\b|\bwith\b|$)/i) || [, ''])[1].trim();
+        const permissive = /using\s*\(\s*true\s*\)/i.test(body) || /with\s+check\s*\(\s*true\s*\)/i.test(body);
+        t(m[2]).policies.set(name, { to, permissive, file: f });
+      } else {
+        t(m[2]).policies.delete(m[1].replace(/"/g, ''));
+      }
+    }
+
+    for (const m of sql.matchAll(/create\s+(?:or\s+replace\s+)?function\s+([\w."]+)\s*\(([\s\S]*?)\$\$/gi)) {
+      if (/security\s+definer/i.test(m[2]) && !/set\s+search_path/i.test(m[2])) {
+        unsafeDefiners.push({ fn: m[1], file: f });
+      }
+    }
+  }
+
+  // Policy permissive senza `TO` esplicito: valgono per PUBLIC, quindi anche anon.
+  // L'allowlist vale anche qui: una tabella pubblica per scelta non è una violazione,
+  // altrimenti il check resta rosso per sempre e smette di essere guardato.
+  const openPolicies = [];
+  const allowedOpen = [];
+  for (const [name, meta] of tables) {
+    for (const [p, d] of meta.policies) {
+      if (d.permissive && (!d.to || /\bpublic\b/i.test(d.to))) {
+        (allowlist[name] ? allowedOpen : openPolicies).push(`${name} :: "${p}" — ${d.file}`);
+      }
+    }
+  }
+
+  const noRls = [...tables].filter(([, v]) => v.created && v.rls !== true).map(([k]) => k);
+
+  return { tables, noRls, openPolicies, allowedOpen, unsafeDefiners };
+}
+
+/** Legge le migration dal filesystem in una mappa { file: sql }. */
+export function readMigrations(dir = MIGRATIONS) {
+  const out = {};
+  for (const f of readdirSync(dir).filter((x) => x.endsWith('.sql')).sort()) {
+    out[f] = readFileSync(join(dir, f), 'utf8');
+  }
+  return out;
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const STATIC_ONLY = process.argv.includes('--static');
+  let violations = 0;
+  const fail = (msg) => { violations++; console.log(`  ✗ ${msg}`); };
+  const ok = (msg) => console.log(`  ✓ ${msg}`);
+
+  console.log('Audit RLS / superficie anon — Maestro (#1391, epic #634)');
+  console.log('\n── Analisi statica delle migration ──\n');
+
+  const { noRls, openPolicies, allowedOpen, unsafeDefiners } = analyzeMigrations(readMigrations());
+
+  console.log(`Tabelle create senza ENABLE ROW LEVEL SECURITY (${noRls.length}):`);
+  noRls.length
+    ? noRls.forEach((n) => fail(`${n} — RLS assente: il GRANT di default la espone via PostgREST`))
+    : ok('nessuna');
+
+  console.log(`\nPolicy USING(true)/WITH CHECK(true) senza "TO" esplicito (${openPolicies.length}):`);
+  openPolicies.length
+    ? openPolicies.forEach((p) => fail(`${p} — vale per PUBLIC, include anon`))
+    : ok('nessuna');
+  for (const p of allowedOpen) console.log(`  ~ ${p} — permissiva ma in allowlist`);
+
+  console.log(`\nFunzioni SECURITY DEFINER senza SET search_path (${unsafeDefiners.length}):`);
+  unsafeDefiners.length
+    ? unsafeDefiners.forEach((d) => console.log(`  ! ${d.fn} — ${d.file} (hardening, non bloccante)`))
+    : ok('nessuna');
+
+  if (!STATIC_ONLY) {
+    console.log('\n── Superficie reale esposta ad anon ──\n');
+    const envPath = join(ROOT, '.env.local');
+    if (!existsSync(envPath)) {
+      console.log('  .env.local assente — controllo runtime saltato.');
+    } else {
+      const env = Object.fromEntries(
+        readFileSync(envPath, 'utf8').split('\n')
+          .filter((l) => l.includes('=') && !l.startsWith('#'))
+          .map((l) => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()]),
+      );
+      const URL = env.NEXT_PUBLIC_SUPABASE_URL;
+      const ANON = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      if (!URL || !ANON) {
+        console.log('  URL/ANON key mancanti — saltato.');
+      } else {
+        const names = new Set();
+        for (const sql of Object.values(readMigrations())) {
+          for (const m of sql.replace(/--[^\n]*/g, '').matchAll(
+            /create\s+(?:table|(?:or\s+replace\s+)?view|materialized\s+view)\s+(?:if\s+not\s+exists\s+)?([\w."]+)/gi,
+          )) {
+            names.add(m[1].replace(/^public\./, '').replace(/"/g, '').toLowerCase());
+          }
+        }
+        let exposed = 0;
+        for (const n of [...names].sort()) {
+          const r = await fetch(`${URL}/rest/v1/${n}?select=*&limit=1`, { headers: { apikey: ANON } });
+          if (!r.ok) continue;
+          const rows = await r.json();
+          if (!Array.isArray(rows) || rows.length === 0) continue;
+          exposed++;
+          if (ANON_READ_ALLOWLIST[n]) {
+            console.log(`  ~ ${n} — leggibile da anon, ma in allowlist: ${ANON_READ_ALLOWLIST[n]}`);
+          } else {
+            fail(`${n} — restituisce righe a un client NON autenticato (colonne: ${Object.keys(rows[0]).join(', ')})`);
+          }
+        }
+        if (exposed === 0) ok('nessuna tabella restituisce righe ad anon');
+      }
+    }
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  if (violations) {
+    console.log(`ESITO: ${violations} violazioni da sanare.`);
+    process.exit(1);
+  }
+  console.log('ESITO: nessuna violazione.');
+}
+
+// Esegue solo se invocato da CLI, non quando importato dai test.
+if (process.argv[1] && process.argv[1].endsWith('security-audit-rls.mjs')) {
+  await main();
+}

--- a/skills/security-review-platform/security-audit-secrets.mjs
+++ b/skills/security-review-platform/security-audit-secrets.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * security-audit-secrets.mjs — cerca credenziali in chiaro nei file versionati
+ * (issue #1392, epic sicurezza #634).
+ *
+ * Nato da un caso reale: `Maestro2026!` era committata in 4 file dal 24/03/2026,
+ * presentata come "credenziale di test". Non lo era — la stessa password apriva
+ * gli account reali in produzione, incluso uno con `is_superadmin`.
+ *
+ * Analizza SOLO i file tracciati da git (`git ls-files`): quel che non è versionato
+ * non è il problema di questo controllo.
+ *
+ * Uso:
+ *   node scripts/security-audit-secrets.mjs
+ *
+ * Exit code 1 se trova qualcosa fuori allowlist → utilizzabile in CI.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** File esclusi dalla scansione: rumore noto, non segreti. */
+const SKIP_FILES = [
+  /^package-lock\.json$/,
+  /^src\/lib\/database\.types\.ts$/,
+  /^scripts\/security-audit-secrets\.mjs$/, // questo file contiene i pattern stessi
+];
+
+/**
+ * Valori che sembrano segreti ma non lo sono. Motivare ogni voce.
+ */
+const ALLOWLIST = [
+  { pattern: /secret123|'secret'|"secret"|'password'|"password"/, why: 'fixture nei test dei validator Zod' },
+  { pattern: /your-public-anon-key|sk-ant-\.\.\.|<[^>]+>|\$\{[^}]+\}|xxx+|\.\.\./i, why: 'placeholder' },
+];
+
+const RULES = [
+  {
+    id: 'password-literale',
+    // password: "qualcosa" / password=qualcosa in JSON, shell, codice
+    re: /["']?password["']?\s*[:=]\s*["'][^"'\s${}]{6,}["']/gi,
+    grave: true,
+    msg: 'password in chiaro',
+  },
+  {
+    id: 'jwt-service-role',
+    re: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}/g,
+    grave: true,
+    msg: 'JWT committato',
+    // Verifica il ruolo dentro il payload: anon è pubblica, service_role no.
+    refine: (m) => {
+      try {
+        const payload = JSON.parse(Buffer.from(m.split('.')[1], 'base64').toString());
+        if (payload.role === 'service_role') return 'JWT SERVICE_ROLE — accesso totale al DB';
+        if (payload.role === 'anon') return null; // chiave pubblica, non è un segreto
+        return `JWT con role=${payload.role}`;
+      } catch { return null; }
+    },
+  },
+  { id: 'api-key-provider', re: /\b(sk-ant-[A-Za-z0-9_-]{10,}|sk-[A-Za-z0-9]{32,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16})\b/g, grave: true, msg: 'API key provider' },
+  { id: 'private-key', re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/g, grave: true, msg: 'chiave privata' },
+];
+
+const files = execSync('git ls-files', { cwd: ROOT, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })
+  .split('\n').filter(Boolean)
+  .filter((f) => !SKIP_FILES.some((re) => re.test(f)));
+
+console.log(`Audit secrets — ${files.length} file versionati (#1392, epic #634)\n`);
+
+let violations = 0;
+const allowed = [];
+
+for (const f of files) {
+  let content;
+  try { content = readFileSync(join(ROOT, f), 'utf8'); } catch { continue; }
+  if (content.includes('\0')) continue; // binario
+
+  for (const rule of RULES) {
+    for (const m of content.matchAll(rule.re)) {
+      const hit = m[0];
+      if (ALLOWLIST.some((a) => a.pattern.test(hit))) { allowed.push(`${f} — ${rule.id}`); continue; }
+
+      let detail = rule.msg;
+      if (rule.refine) {
+        const refined = rule.refine(hit);
+        if (refined === null) continue; // scartato dal refine (es. JWT anon)
+        detail = refined;
+      }
+      const line = content.slice(0, m.index).split('\n').length;
+      violations++;
+      console.log(`  ✗ ${f}:${line} — ${detail}`);
+    }
+  }
+}
+
+if (allowed.length) {
+  console.log(`\n  ~ ${allowed.length} occorrenze in allowlist (placeholder e fixture di test)`);
+}
+
+console.log(`\n${'─'.repeat(60)}`);
+if (violations) {
+  console.log(`ESITO: ${violations} credenziali in chiaro da rimuovere.`);
+  console.log('Rimuovere dal codice NON basta: la credenziale resta nella history git.');
+  console.log('Va ANCHE ruotata (cambiata) sul sistema che protegge.');
+  process.exit(1);
+}
+console.log('ESITO: nessuna credenziale in chiaro nei file versionati.');


### PR DESCRIPTION
Skill nata dall'epic sicurezza #634 su MaestroWeb: 2 finding critici, 6 alti.

Diversa da `security-audit` (gate pre-push su un diff). Questa è una **review di postura** su un sistema già in produzione: superficie dati, credenziali, header/TLS, auth, GDPR, VPS.

## Perché non è una checklist

Il valore sta nei tranelli, non nell'elenco delle aree. In **ogni** caso reale la lettura del codice avrebbe prodotto un falso negativo:

| Sembrava | Era |
|---|---|
| Migration con policy RLS corrette | 6 tabelle leggibili senza login — le policy vere non erano nelle migration |
| `iptables -L` con DROP attivo sulla porta | Porta aperta: `--dport` vede la porta interna dopo il DNAT |
| Timer systemd `enabled` + `active` | Mai scattato: `RemainAfterExit=yes` blocca il rilancio |
| Header di sicurezza nella config nginx | Assenti sugli asset: `add_header` non si eredita |
| Credenziali "di test" | Aprivano la produzione da 4 mesi, con privilegi superadmin |

Da qui il principio: **ogni finding va verificato dall'esterno con una richiesta reale**. «Non verificato» è un esito legittimo da scrivere; una deduzione presentata come verifica no.

## Contenuto

6 fasi, ognuna con i tranelli specifici — fra gli altri: le view non ereditano la RLS della tabella base; un `204` su 0 righe non prova il permesso di scrittura; un account superadmin non può validare le policy di scope; Docker bypassa UFW e serve `--ctorigdstport`; una CSP va introdotta in Report-Only.

Include i due script riutilizzabili (`security-audit-rls.mjs`, `security-audit-secrets.mjs`): audit RLS statico+runtime e ricerca credenziali con decodifica del payload JWT per distinguere `anon` da `service_role`. Da adattare solo nel path delle migration e del file di ambiente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MporyB65PcYioGzgFwYb3N