### PR TITLE
Un lotto approvato sull'epica ora arriva davvero in produzione

### DIFF
--- a/skills/beta-release/SKILL.md
+++ b/skills/beta-release/SKILL.md
@@ -93,7 +93,20 @@ codice non approvato** — non è più sicuro farlo, se il repo ha lo script di 
 **Se il repo ha `scripts/approva-promote.ts` (oggi solo maestroweb — verifica con
 `ls scripts/approva-promote.ts` prima di procedere)**, usa quello al posto del merge intero:
 
+**Prima del dry-run — lotto revisionato su un'EPICA?** Se l'approvazione di Ascanio è arrivata su
+una scheda riassuntiva, `qa-approved` sta **solo** sull'epica e lo script non la vede: l'epica non
+ha commit propri, e la selezione avviene sulle issue collegate ai commit. Il report dirà «Nessuna
+issue qa-approved», che sembra «non c'è niente da fare» ed è invece un lotto approvato che resta
+fermo. Propaga la label alle figlie elencate nell'epica **prima** di procedere — procedura completa
+e vincoli in `issue-approve` Step 0b.
+
 ```bash
+# 0. Se `npx tsx` non parte («tsx non è riconosciuto»), node_modules/.bin può essere vuoto:
+#    node node_modules/tsx/dist/cli.mjs scripts/approva-promote.ts --dry-run
+# 0b. Sincronizza il branch main LOCALE prima di lanciare, o un main stale riporta indietro la
+#     working copy e lo script sparisce dal filesystem a metà run:
+git fetch origin main && git branch -f main origin/main
+
 # 1. Sempre un dry-run PRIMA del run reale — non salta mai questo passaggio
 npx tsx scripts/approva-promote.ts --dry-run
 # Controlla il report: quali issue PROMOSSE, quali ESCLUSE (non approvate), quali NON

--- a/skills/issue-approve/SKILL.md
+++ b/skills/issue-approve/SKILL.md
@@ -46,6 +46,41 @@ git ls-remote --heads origin beta
 > Questo perché con merge-diretto-in-beta il branch contiene sempre issue approvate e non
 > approvate mescolate.
 
+### ⛔ Step 0b — Se la revisione è avvenuta su un'EPICA: propaga `qa-approved` alle figlie
+
+Quando più issue dello stesso filone vengono revisionate su **una scheda riassuntiva** (epica) invece
+che una per una, l'approvazione di Ascanio arriva **solo sull'epica**: la label `qa-approved` viene
+applicata lì dall'automatismo di `/qa`, e le figlie restano senza.
+
+`scripts/approva-promote.ts` cerca `qa-approved` sulle issue **collegate ai commit** — e un'epica
+non ha commit propri. Risultato: **un lotto regolarmente approvato non viene promosso, e il report
+dice «Nessuna issue qa-approved» senza che nulla sia andato storto.** Nessun errore, nessun avviso:
+solo un run che non promuove niente.
+
+Prima di lanciare la promozione, quindi:
+
+```bash
+# 1. l'epica è qa-approved?
+gh issue view <EPICA> --repo ecologicaleaving/<repo> --json labels -q '[.labels[].name]'
+
+# 2. propaga alle figlie elencate nell'epica
+for n in <FIGLIA_1> <FIGLIA_2> ...; do
+  gh issue edit $n --repo ecologicaleaving/<repo> --add-label qa-approved
+done
+```
+
+**Su ogni figlia lascia un commento che dice dove l'approvazione è avvenuta davvero** (epica, data,
+chi). La label significa letteralmente «criteri approvati da Ascanio su /qa»: senza la nota, fra un
+mese la storia dirà che ogni scheda è stata revisionata singolarmente — cosa mai accaduta.
+
+Non propagare mai `qa-approved` a una figlia che l'epica **non** elenca: la promozione è per gruppo
+di commit, e una figlia in più porta in produzione codice che nessuno ha approvato.
+
+> Origine: 12/08/2026, maestroweb — epica #1680 con figlie #1676/#1677/#1678/#1679/#1681. Ascanio
+> approva tutti gli AC sull'epica, la label arriva lì, e il dry-run di promozione risponde «niente
+> da promuovere». Il buco è **strutturale**, non un errore di esecuzione: si ripresenta a ogni
+> lotto revisionato su epica finché lo script non saprà risolvere epica→figlie da solo.
+
 ### Step 1 — Merge PR
 
 ```bash


### PR DESCRIPTION
## Il problema

Quando più issue dello stesso filone vengono revisionate su una **scheda riassuntiva** (epica), Ascanio approva gli Acceptance Criteria lì e l'automatismo di `/qa` applica `qa-approved` **sull'epica**. Le figlie restano senza.

`scripts/approva-promote.ts` seleziona i commit da promuovere cercando la label sulle issue **collegate ai commit** — e un'epica non ha commit propri. Il dry-run risponde «Nessuna issue qa-approved», che si legge come «non c'era niente da fare», mentre in realtà **un lotto regolarmente approvato resta fermo su `beta`**. Nessun errore, nessun avviso.

Non è un errore di esecuzione: è strutturale, e si ripresenta a ogni lotto revisionato su epica.

## Cosa cambia

- **`issue-approve` Step 0b** — propagazione di `qa-approved` alle sole figlie elencate nell'epica, con l'obbligo di annotare su ognuna dove l'approvazione è avvenuta davvero. La label significa letteralmente «criteri approvati da Ascanio su /qa»: senza la nota, fra un mese la storia direbbe che ogni scheda è stata revisionata singolarmente, cosa mai accaduta. Vietato propagarla a figlie che l'epica non elenca — la promozione è per gruppo di commit, e una figlia in più porta in prod codice che nessuno ha approvato.
- **`beta-release` Step 5** — il rimando prima del dry-run, dove il problema si manifesta. Più due inciampi già costati tempo: `npx tsx` non parte se `node_modules/.bin` è vuoto, e un `main` locale stale fa sparire lo script dal filesystem a metà run.

## Origine

12/08/2026, maestroweb: epica #1680 con figlie #1676, #1677, #1678, #1679, #1681. Ascanio approva tutti gli AC sull'epica, e il dry-run di promozione non promuove nulla.

## Nota

Solo documentazione di processo: nessuno script modificato. La soluzione definitiva sarebbe insegnare a `approva-promote.ts` a risolvere epica→figlie da sé; finché non esiste, questo passaggio va fatto a mano e ora è scritto dove lo si cerca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhxVS5XiPCpSZAqBXL3YuS