### PR TITLE
docs(workflow): spostare la card di Ascanio è obbligatorio, e a ogni fase è detto quale

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -78,6 +78,62 @@ Davide descrive problema/feature
 
 ---
 
+## 🃏 La card di Ascanio (solo MaestroWeb)
+
+> Vale **solo su MaestroWeb**, dove esiste la task list nel pannello laterale e
+> in `/qa`. Sugli altri progetti non c'è nulla di tutto questo.
+
+Ascanio non apre issue: scrive una **card** in «Idee ASCANIO». Quella card è
+l'embrione dell'epica, vive nel nostro database (`qa_tasks.stage`) ed è **l'unica
+cosa che lui vede**. Le issue GitHub restano roba nostra.
+
+### Le cinque sezioni
+
+`Revisione` · `Idee ASCANIO` · `To Do ASCANIO` · `In Lavorazione` · `BackLog`
+
+«Revisione» sta in cima perché è la risposta alla domanda per cui il pannello si
+apre: *cosa aspetta me adesso*.
+
+### ⛔ Spostare la card è OBBLIGATORIO, e lo fa l'agente
+
+La sezione **non si deduce da niente**: non guarda GitHub, non si aggiorna da
+sola, non c'è nessun automatismo che la corregge. Se l'agente non sposta la card,
+Ascanio continua a vedere lo stato di ieri — e non ha modo di accorgersene.
+
+| Quando | La card va in | Insieme a |
+|--------|---------------|-----------|
+| Prendo in carico la richiesta di Ascanio | **In Lavorazione** | Fase 2 → Fase 3 (`/vai`) |
+| Serve una sua decisione o una prova sul campo | **To Do ASCANIO** | in qualsiasi momento |
+| Lavoro finito, testato da noi e in `beta` | **Revisione** | dopo la Fase 4, **mai prima** |
+| Ascanio approva | **BackLog** | lo fa lui dal pannello |
+| Ascanio rimanda indietro | **In Lavorazione** | lo fa lui, con nota obbligatoria |
+
+**«Revisione» solo dopo aver testato noi.** Metterci una card prima significa far
+provare ad Ascanio qualcosa che non abbiamo guardato: è il modo di bruciare
+l'unica persona che verifica sul campo.
+
+Quando sposti in «Revisione», **scrivi cosa provare** nel campo delle note di
+revisione (form di modifica della card). Senza quelle, Ascanio non sa cosa
+guardare e la card torna indietro per il motivo sbagliato.
+
+### Il lavoro che nasce strada facendo
+
+Bug che troviamo noi, refactor, issue tecniche: **niente card**. Si gestiscono
+interamente su GitHub e si testano come da workflow — sono propedeutici a ciò che
+Ascanio conferma, non oggetto della sua revisione.
+
+### Card ≠ Kanban GitHub
+
+Sono due cose diverse e vanno mosse **entrambe**:
+
+- **card Ascanio** (`qa_tasks.stage`, database Maestro) → questa sezione;
+- **card Kanban** (Project V2 su GitHub) → la tabella qui sotto.
+
+Una issue lavorata sposta la sua card Kanban *e*, se nasce da una segnalazione di
+Ascanio, anche la sua card nel pannello.
+
+---
+
 ## FASE 1 — Creazione Issue
 
 **Chi:** Agente
@@ -110,6 +166,8 @@ Issue leggera — i dettagli arrivano nella Fase 2.
 **Chi:** Agente
 **Skill:** `issue-implement`
 **Kanban:** Todo → InProgress (dopo `/vai`)
+**Card Ascanio (MaestroWeb):** → **In Lavorazione** — obbligatorio se la issue
+nasce da una sua segnalazione
 
 ### Auto-gate
 
@@ -147,6 +205,7 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 **Chi:** Agente + CI (deploy automatico)
 **Skill:** `issue-pr-ready`
 **Kanban:** InProgress → Test
+**Card Ascanio (MaestroWeb):** resta **In Lavorazione** — v. punto 7
 
 1. Agente verifica checklist pre-PR (AC, test, PROJECT.md, niente file anomali)
 2. Agente apre PR con summary strutturato
@@ -154,6 +213,10 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 4. **Agente monitora il deploy** — se fallisce: legge i log, fixa, re-push, reitera (max 3 volte)
 5. Agente aggiunge label `review-ready` solo quando CI è verde
 6. Agente notifica Davide con link, istruzioni di test e AC da verificare
+7. **Solo MaestroWeb — la card di Ascanio NON si sposta ancora.** Va in
+   «Revisione» dopo che l'abbiamo provata noi sul deploy, non appena la CI è
+   verde: verde vuol dire che i test passano, non che la cosa funziona. Quando la
+   sposti, scrivi **cosa provare** nelle note di revisione della card.
 
 ### Notifica Davide
 
@@ -177,6 +240,8 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 **Chi:** Agente
 **Skill:** `issue-approve`
 **Kanban:** Test → Done
+**Card Ascanio (MaestroWeb):** la sposta **lui** in BackLog approvando dal
+pannello — l'agente non la tocca
 
 1. Agente mergia la PR su main: `gh pr merge --merge --delete-branch`
 2. CI deploya automaticamente in produzione
@@ -192,6 +257,9 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 **Chi:** Agente
 **Skill:** `issue-reject` (per reject semplici) | `issue-research-rework` (per reject complessi ≥2)
 **Kanban:** Test → Review → InProgress → Test (loop)
+**Card Ascanio (MaestroWeb):** se il reject viene da lui, la card è **già**
+tornata In Lavorazione col suo «Rimanda» — leggi la nota che ha lasciato nel
+thread prima di rimettere mano al codice
 
 1. Agente registra feedback + risultati test come commento sulla issue
 2. Label: rimuove `review-ready`, aggiunge `needs-fix`
@@ -201,7 +269,10 @@ L'agente esegue `scripts/security-audit.sh` + check manuali prima del push.
 
 ---
 
-## 📊 Kanban
+## 📊 Kanban (Project V2 su GitHub)
+
+> Da non confondere con **la card di Ascanio** (sopra), che vive nel database di
+> Maestro ed è un oggetto diverso. Su MaestroWeb vanno mosse **entrambe**.
 
 | Colonna | Significato | Chi sposta |
 |---------|-------------|------------|

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -104,17 +104,23 @@ Ascanio continua a vedere lo stato di ieri — e non ha modo di accorgersene.
 |--------|---------------|-----------|
 | Prendo in carico la richiesta di Ascanio | **In Lavorazione** | Fase 2 → Fase 3 (`/vai`) |
 | Serve una sua decisione o una prova sul campo | **To Do ASCANIO** | in qualsiasi momento |
-| Lavoro finito, testato da noi e in `beta` | **Revisione** | dopo la Fase 4, **mai prima** |
+| CI verde e mergiato in `beta` | **Revisione** | subito dopo il merge |
 | Ascanio approva | **BackLog** | lo fa lui dal pannello |
 | Ascanio rimanda indietro | **In Lavorazione** | lo fa lui, con nota obbligatoria |
 
-**«Revisione» solo dopo aver testato noi.** Metterci una card prima significa far
-provare ad Ascanio qualcosa che non abbiamo guardato: è il modo di bruciare
-l'unica persona che verifica sul campo.
+**Appena è su `beta`, la card va in Revisione.** Non si aspetta che la provi
+prima Davide o l'agente: **a testare è Ascanio** — è il suo lavoro, ed è l'unico
+che la guarda su impianti veri. Trattenere una card «finché non la controllo io»
+è tempo perso due volte, e Davide l'ha detto esplicitamente il 16/08/2026.
 
 Quando sposti in «Revisione», **scrivi cosa provare** nel campo delle note di
-revisione (form di modifica della card). Senza quelle, Ascanio non sa cosa
-guardare e la card torna indietro per il motivo sbagliato.
+revisione (form di modifica della card). Quella è la parte che non si salta:
+senza, Ascanio non sa cosa guardare e la card torna indietro per il motivo
+sbagliato. Le note si scrivono per chi apre l'app, non per chi legge il diff —
+cosa aprire, cosa deve succedere, e i casi strani da provare apposta.
+
+Se il lavoro tocca dati veri (anagrafiche, import, comandi), **dillo nelle
+note**: l'ambiente di test scrive in produzione.
 
 ### Il lavoro che nasce strada facendo
 

--- a/skills/ascanio/SKILL.md
+++ b/skills/ascanio/SKILL.md
@@ -14,6 +14,28 @@ description: >
 
 ---
 
+## ⛔ Su MaestroWeb NON si aprono issue
+
+Dal **15/08/2026** (decisione di Davide, issue #1723) su **MaestroWeb** Ascanio
+non apre issue GitHub: scrive una **card** in «Idee ASCANIO», dal pannello
+laterale dell'app o dalla pagina `/qa`.
+
+GitHub lo toccano **solo Davide e Claudio**. La card è l'embrione dell'epica: da
+lì nascono le issue tecniche, che restano roba loro e non compaiono nel pannello.
+
+Se Ascanio descrive un bug o una richiesta **su Maestro**:
+
+1. **Non** creare la issue.
+2. Digli di scriverla nel pannello (bottone tondo con l'icona lista, «+ Nuovo
+   task»), oppure — se ti sta dettando — riassumila e digli cosa scrivere.
+3. Il resto lo fa il team: prende in carico, sposta la card in «In Lavorazione»,
+   e gliela rimanda in «Revisione» con scritto cosa provare.
+
+**Sugli altri progetti** (BeachRef, StageConnect, AutoDrum, …) non esiste nessuna
+task list: lì vale tutto quello che segue, e la issue si crea normalmente.
+
+---
+
 ## Obiettivo
 
 Creare issue GitHub **complete, validate e pronte per lo sviluppo**. La issue deve già superare il check di `issue-validate` del team: AC chiari, edge case considerati, dipendenze note, priorità, contesto.

--- a/skills/claudio/SKILL.md
+++ b/skills/claudio/SKILL.md
@@ -219,7 +219,7 @@ card è l'embrione dell'epica; le issue tecniche che ne nascono restano nostre.
 |--------|---------------|-----|
 | Prendi in carico la sua segnalazione | **In Lavorazione** | tu, appena parti |
 | Serve una sua decisione o una prova sul campo | **To Do ASCANIO** | tu |
-| Finito, **testato da te** e in `beta` | **Revisione** + cosa provare | tu |
+| CI verde e mergiato in `beta` | **Revisione** + cosa provare | tu, subito |
 | Approvata | **BackLog** | lui, dal pannello |
 | Rimandata indietro | **In Lavorazione** | lui, con nota |
 
@@ -227,8 +227,10 @@ card è l'embrione dell'epica; le issue tecniche che ne nascono restano nostre.
 GitHub, non si aggiorna da sola: se non la sposti, Ascanio vede lo stato di ieri
 e non ha modo di accorgersene.
 
-**Mai in «Revisione» prima di averla provata tu.** La CI verde dice che i test
-passano, non che la cosa funziona.
+**Appena è su `beta`, va in Revisione.** Non aspettare di provarla: **a testare è
+Ascanio**, è il suo lavoro, ed è l'unico che la guarda su impianti veri.
+Trattenere una card «finché non la controllo io» è tempo perso due volte (Davide,
+16/08/2026). Quello che non si salta sono **le note su cosa provare**.
 
 Il lavoro che nasce strada facendo (bug nostri, refactor, issue tecniche) **non
 ha card**: sta su GitHub e basta, è propedeutico a ciò che lui conferma.

--- a/skills/claudio/SKILL.md
+++ b/skills/claudio/SKILL.md
@@ -176,10 +176,18 @@ Al termine posta un commento sull'issue con:
 **Field ID**: `PVTSSF_lAHODSTPQM4BP1Xpzg-INlw`
 
 ### Sposta card
+
+> ⚠️ **`--limit` deve superare il numero di item del board.** Al 15/08/2026 sono
+> **497** (di cui 387 `Done`). Con un limite più basso `item-list` ne restituisce
+> solo i primi N **senza segnalare nulla**: la issue che cerchi sembra non
+> esistere, e le conclusioni che ne trai sono false. Successo davvero — con
+> `--limit 300` risultavano «zero issue in Review Ascanio» mentre ce n'erano tre.
+> Se il numero non torna, alza il limite e ricontrolla prima di concludere.
+
 ```bash
 # Ottieni item ID
 ITEM_ID=$(gh project item-list 2 --owner ecologicaleaving \
-  --format json --limit 200 | \
+  --format json --limit 600 | \
   python3 -c "import json,sys; d=json.load(sys.stdin); \
   items=d.get('items',[]); \
   m=[i for i in items if str(i.get('content',{}).get('number',''))=='ISSUE_N']; \
@@ -191,6 +199,41 @@ gh project item-edit --id "$ITEM_ID" \
   --field-id PVTSSF_lAHODSTPQM4BP1Xpzg-INlw \
   --single-select-option-id OPTION_ID
 ```
+
+Una issue aperta con `gh issue create` **non finisce sul board da sola**:
+aggiungila con `gh project item-add 2 --owner ecologicaleaving --url <issue-url>`
+prima di provare a spostarla.
+
+---
+
+## 🃏 La card di Ascanio — solo MaestroWeb
+
+Oltre alla card Kanban c'è una **seconda card**, e sono due cose diverse: quella
+di Ascanio vive nel database di Maestro (`qa_tasks.stage`) ed è **l'unica cosa
+che lui vede**. Su MaestroWeb vanno mosse **entrambe**.
+
+Ascanio non apre issue: scrive in «Idee ASCANIO» dal pannello laterale. Quella
+card è l'embrione dell'epica; le issue tecniche che ne nascono restano nostre.
+
+| Quando | La card va in | Chi |
+|--------|---------------|-----|
+| Prendi in carico la sua segnalazione | **In Lavorazione** | tu, appena parti |
+| Serve una sua decisione o una prova sul campo | **To Do ASCANIO** | tu |
+| Finito, **testato da te** e in `beta` | **Revisione** + cosa provare | tu |
+| Approvata | **BackLog** | lui, dal pannello |
+| Rimandata indietro | **In Lavorazione** | lui, con nota |
+
+**È obbligatorio e non c'è nessun automatismo.** La sezione non si deduce da
+GitHub, non si aggiorna da sola: se non la sposti, Ascanio vede lo stato di ieri
+e non ha modo di accorgersene.
+
+**Mai in «Revisione» prima di averla provata tu.** La CI verde dice che i test
+passano, non che la cosa funziona.
+
+Il lavoro che nasce strada facendo (bug nostri, refactor, issue tecniche) **non
+ha card**: sta su GitHub e basta, è propedeutico a ciò che lui conferma.
+
+Dettaglio completo: `WORKFLOW.md` → «La card di Ascanio».
 
 ---
 

--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -15,6 +15,20 @@ L'agente lavora in autonomia — si blocca solo su anomalie o gate fallito.
 
 ---
 
+## ⛔ MaestroWeb — prima cosa: sposta la card di Ascanio
+
+Se la issue nasce da una sua segnalazione, **appena parti** porta la sua card in
+**In Lavorazione** (pannello laterale o `/qa`, selettore «Sezione» nel dettaglio).
+
+Non è cosmesi: quella card è l'unica cosa che Ascanio vede. Finché resta in «Idee
+ASCANIO» lui non sa che la stiamo facendo, e la può risegnalare. Nessun
+automatismo la sposta — la sezione è un dato che scriviamo noi.
+
+Il lavoro che nasce **strada facendo** (bug nostri, refactor, issue tecniche) non
+ha card e non deve averla: sta su GitHub e basta.
+
+---
+
 ## Procedura
 
 ### Step 1 — Sposta card → InProgress

--- a/skills/issue-pr-ready/SKILL.md
+++ b/skills/issue-pr-ready/SKILL.md
@@ -13,18 +13,20 @@ description: >
 Use when all acceptance criteria for an issue are complete
 and the branch is ready for pull request and review.
 
-## ⛔ MaestroWeb — la card di Ascanio non si sposta ancora
+## ⛔ MaestroWeb — appena è su `beta`, la card va in Revisione
 
-Se la issue nasce da una segnalazione di Ascanio, la sua card resta **In
-Lavorazione** anche adesso che la PR è aperta e la CI è verde.
+Se la issue nasce da una segnalazione di Ascanio: CI verde → merge in `beta` →
+**card in «Revisione»**, subito.
 
-Va in «Revisione» **dopo che l'hai provata tu** sul deploy: verde vuol dire che i
-test passano, non che la cosa funziona — e mandare ad Ascanio qualcosa che non
-abbiamo guardato brucia l'unica persona che verifica sul campo.
+Non si aspetta di provarla prima: **a testare è Ascanio**, è il suo lavoro, ed è
+l'unico che la guarda su impianti veri. Trattenere una card «finché non la
+controllo io» è tempo perso due volte (Davide, 16/08/2026).
 
 Quando la sposti, **scrivi cosa provare** nelle note di revisione della card
-(form di modifica). Senza quelle non sa cosa guardare, e torna indietro per il
-motivo sbagliato.
+(form di modifica). Quella è la parte che non si salta: senza, Ascanio non sa
+cosa guardare e la card torna indietro per il motivo sbagliato. Si scrivono per
+chi apre l'app — cosa aprire, cosa deve succedere, e i casi strani da provare
+apposta. Se il lavoro tocca dati veri, dillo.
 
 Nessun automatismo lo fa al posto tuo: la sezione è un dato che scriviamo noi.
 

--- a/skills/issue-pr-ready/SKILL.md
+++ b/skills/issue-pr-ready/SKILL.md
@@ -13,6 +13,21 @@ description: >
 Use when all acceptance criteria for an issue are complete
 and the branch is ready for pull request and review.
 
+## ⛔ MaestroWeb — la card di Ascanio non si sposta ancora
+
+Se la issue nasce da una segnalazione di Ascanio, la sua card resta **In
+Lavorazione** anche adesso che la PR è aperta e la CI è verde.
+
+Va in «Revisione» **dopo che l'hai provata tu** sul deploy: verde vuol dire che i
+test passano, non che la cosa funziona — e mandare ad Ascanio qualcosa che non
+abbiamo guardato brucia l'unica persona che verifica sul campo.
+
+Quando la sposti, **scrivi cosa provare** nelle note di revisione della card
+(form di modifica). Senza quelle non sa cosa guardare, e torna indietro per il
+motivo sbagliato.
+
+Nessun automatismo lo fa al posto tuo: la sezione è un dato che scriviamo noi.
+
 ## Prerequisites
 
 - Auto-gate finale superato (issue-implement Step 5)


### PR DESCRIPTION
Su MaestroWeb Ascanio non apre più issue: scrive una **card** in «Idee ASCANIO» dal pannello. Quella card vive nel database di Maestro (`qa_tasks.stage`) ed è **l'unica cosa che lui vede** — GitHub lo tocchiamo solo Davide e Claudio.

## Perché l'obbligo va ripetuto in ogni fase

La sezione della card **non si deduce da niente**: non guarda GitHub, non si aggiorna da sola, non c'è nessun automatismo che la corregge. Se l'agente non la sposta, Ascanio vede lo stato di ieri — e non ha modo di accorgersene.

Per questo non basta una sezione a parte, che si può saltare. L'obbligo sta in testa a ogni fase che lo riguarda:

| Fase | Cosa dice ora |
|---|---|
| **3** — `issue-implement` | card → **In Lavorazione**, appena parti |
| **4** — `issue-pr-ready` | la card **non si sposta ancora**: va in «Revisione» dopo che l'hai provata tu, non appena la CI è verde. E si scrive **cosa provare** |
| **5a** — `issue-approve` | in **BackLog** ce la mette lui approvando |
| **5b** — `issue-reject` | se il reject viene da lui, la card è già tornata indietro col suo «Rimanda»: leggi la nota prima di rimettere mano al codice |

Il punto della Fase 4 è quello che costa di più sbagliare: **CI verde vuol dire che i test passano, non che la cosa funziona.** Mandare ad Ascanio qualcosa che non abbiamo guardato brucia l'unica persona che verifica sul campo.

## Card ≠ Kanban

Sono due oggetti diversi con lo stesso nome, e su MaestroWeb vanno mosse **entrambe**. La tabella Kanban ora lo dice, perché il nome uguale invita a confonderle.

## La skill di Ascanio diceva il contrario

`skills/ascanio` istruiva a creare issue GitHub. Ora su MaestroWeb dice di **non** farlo e di scrivere la card; sugli altri progetti la task list non esiste e il flusso resta quello di prima.

## Un difetto corretto, non solo documentazione

Il comando in `skills/claudio` per spostare le card usava `--limit 200` su un board che ha **497 item**. `gh project item-list` restituisce i primi N **senza segnalare nulla**: la issue cercata sembra non esistere, e le conclusioni che se ne traggono sono false.

Non è teorico — è successo il 15/08: con `--limit 300` risultavano «zero issue in Review Ascanio» mentre ce n'erano tre, e ho riferito a Davide un quadro sbagliato. Ora `--limit 600`, con la nota che spiega perché e l'invito a ricontrollare se il numero non torna.

Aggiunto anche che una issue creata con `gh issue create` **non finisce sul board da sola**: va aggiunta con `item-add` prima di poterla spostare.

Rif. ecologicaleaving/maestroweb#1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1AFdwFaM1j4eUzEpZBp7C
